### PR TITLE
Restrict the reset css to the wpnc__main class.

### DIFF
--- a/src/boot/stylesheets/shared/reset.scss
+++ b/src/boot/stylesheets/shared/reset.scss
@@ -1,79 +1,73 @@
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, font, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td {
-	border: 0;
-	font-family: inherit;
-	font-size: 100%;
-	font-style: inherit;
-	font-weight: inherit;
-	margin: 0;
-	outline: 0;
-	padding: 0;
-	vertical-align: baseline;
-}
-html {
-	font-size: 62.5%; /* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
-	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
-	-ms-text-size-adjust: 100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
-}
-body {
-	background: #fff;
-}
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-nav,
-section {
-	display: block;
-}
-ol, ul {
-	list-style: none;
-}
-table { /* tables still need 'cellspacing="0"' in the markup */
-	border-collapse: separate;
-	border-spacing: 0;
-}
-caption, th, td {
-	font-weight: normal;
-	text-align: left;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: "";
-}
-blockquote, q {
-	quotes: "" "";
-}
-a:focus {
-	outline: thin dotted;
-}
-a:hover,
-a:active { /* Improves readability when focused and also mouse hovered in all browsers people.opera.com/patrickl/experiments/keyboard/test */
-	outline: 0;
-}
-a img {
-	border: 0;
-}
+.wpnc__main {
+  div, span, applet, object, iframe,
+  h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+  a, abbr, acronym, address, big, cite, code,
+  del, dfn, em, font, ins, kbd, q, s, samp,
+  small, strike, strong, sub, sup, tt, var,
+  dl, dt, dd, ol, ul, li,
+  fieldset, form, label, legend,
+  table, caption, tbody, tfoot, thead, tr, th, td {
+  	border: 0;
+  	margin: 0;
+    font-family: inherit;
+    font-size: 100%;
+    font-style: inherit;
+    font-weight: inherit;
+  	outline: 0;
+  	padding: 0;
+  	vertical-align: baseline;
+  }
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  nav,
+  section {
+  	display: block;
+  }
+  ol, ul {
+  	list-style: none;
+  }
+  table { /* tables still need 'cellspacing="0"' in the markup */
+  	border-collapse: separate;
+  	border-spacing: 0;
+  }
+  caption, th, td {
+  	font-weight: normal;
+  	text-align: left;
+  }
+  blockquote:before, blockquote:after,
+  q:before, q:after {
+  	content: "";
+  }
+  blockquote, q {
+  	quotes: "" "";
+  }
+  a:focus {
+  	outline: thin dotted;
+  }
+  a:hover,
+  a:active { /* Improves readability when focused and also mouse hovered in all browsers people.opera.com/patrickl/experiments/keyboard/test */
+  	outline: 0;
+  }
+  a img {
+  	border: 0;
+  }
 
-// Reset the default styling on form inputs in Webkit/iOS
-input,
-textarea {
-	border-radius: 0;
-	-webkit-appearance: none; // Autoprefixer does not support appearance
-	appearance: none;
-	overflow: auto;
-}
-input[type="radio"],
-input[type="checkbox"] {
-	-webkit-appearance: none;
+  // Reset the default styling on form inputs in Webkit/iOS
+  input,
+  textarea {
+  	border-radius: 0;
+  	-webkit-appearance: none; // Autoprefixer does not support appearance
+  	appearance: none;
+  	overflow: auto;
+  }
+  input[type="radio"],
+  input[type="checkbox"] {
+  	-webkit-appearance: none;
+  }
 }


### PR DESCRIPTION
This will require us to add a bit of css to wherever we are using the iframe client as we need the body tag to have a transparent background (or maybe there's a way to fix it without that, needs exploration).