### PR TITLE
CSS: Fix button class conflict w/ Calypso

### DIFF
--- a/src/boot/stylesheets/shared/buttons.scss
+++ b/src/boot/stylesheets/shared/buttons.scss
@@ -2,199 +2,201 @@
 // Buttons - From wp-calypso
 // ==========================================================================
 
-// resets button styles
-button {
-	background: transparent;
-	border: none;
-	outline: 0;
-	padding: 0;
-	font-size: 14px;
-	-webkit-appearance: none;
-	appearance: none;
-	vertical-align: baseline;
-}
+.wpnc__main {
+	// resets button styles
+	button {
+		background: transparent;
+		border: none;
+		outline: 0;
+		padding: 0;
+		font-size: 14px;
+		-webkit-appearance: none;
+		appearance: none;
+		vertical-align: baseline;
+	}
 
-.button {
-	background: $white;
-	border-color: lighten( $gray, 20% );
-	border-style: solid;
-	border-width: 1px 1px 2px;
-	color: $gray-dark;
-	cursor: pointer;
-	display: inline-block;
-	margin: 0;
-	outline: 0;
-	overflow: hidden;
-	font-weight: 500;
-	text-overflow: ellipsis;
-	text-decoration: none;
-	vertical-align: top;
-	box-sizing: border-box;
-	font-size: 14px;
-	line-height: 21px;
-	border-radius: 4px;
-	padding: 7px 14px 9px;
-	-webkit-appearance: none;
-	appearance: none;
-
-	&:hover {
-		border-color: lighten( $gray, 10% );
-		color: $gray-dark;
-	}
-	&:active {
-		border-width: 2px 1px 1px;
-	}
-	&:visited {
-		color: $gray-dark;
-	}
-	&[disabled],
-	&:disabled {
-		color: lighten( $gray, 30% );
+	.button {
 		background: $white;
-		border-color: lighten( $gray, 30% );
-		cursor: default;
+		border-color: lighten( $gray, 20% );
+		border-style: solid;
+		border-width: 1px 1px 2px;
+		color: $gray-dark;
+		cursor: pointer;
+		display: inline-block;
+		margin: 0;
+		outline: 0;
+		overflow: hidden;
+		font-weight: 500;
+		text-overflow: ellipsis;
+		text-decoration: none;
+		vertical-align: top;
+		box-sizing: border-box;
+		font-size: 14px;
+		line-height: 21px;
+		border-radius: 4px;
+		padding: 7px 14px 9px;
+		-webkit-appearance: none;
+		appearance: none;
 
-		&:active {
-			border-width: 1px 1px 2px;
+		&:hover {
+			border-color: lighten( $gray, 10% );
+			color: $gray-dark;
 		}
-	}
-	&:focus {
-		border-color: $blue-medium;
-		box-shadow: 0 0 0 2px $blue-light;
-	}
-	&.is-compact {
-		padding: 7px;
-		color: darken( $gray, 10% );
-		font-size: 11px;
-		line-height: 1;
-		text-transform: uppercase;
-
+		&:active {
+			border-width: 2px 1px 1px;
+		}
+		&:visited {
+			color: $gray-dark;
+		}
+		&[disabled],
 		&:disabled {
 			color: lighten( $gray, 30% );
+			background: $white;
+			border-color: lighten( $gray, 30% );
+			cursor: default;
+
+			&:active {
+				border-width: 1px 1px 2px;
+			}
+		}
+		&:focus {
+			border-color: $blue-medium;
+			box-shadow: 0 0 0 2px $blue-light;
+		}
+		&.is-compact {
+			padding: 7px;
+			color: darken( $gray, 10% );
+			font-size: 11px;
+			line-height: 1;
+			text-transform: uppercase;
+
+			&:disabled {
+				color: lighten( $gray, 30% );
+			}
+			.gridicon {
+				top: 4px;
+				margin-top: -8px;
+			}
+		}
+		&.hidden {
+			display: none;
 		}
 		.gridicon {
-			top: 4px;
-			margin-top: -8px;
+			position: relative;
+				top: 4px;
+			margin-top: -2px;
+			width: 18px;
+			height: 18px;
 		}
 	}
-	&.hidden {
-		display: none;
-	}
-	.gridicon {
-		position: relative;
-			top: 4px;
-		margin-top: -2px;
-		width: 18px;
-		height: 18px;
-	}
-}
 
-// Primary buttons
-.button.is-primary {
-	background: $blue-medium;
-	border-color: $blue-wordpress;
-	color: $white;
-
-	&:hover,
-	&:focus {
-		border-color: $blue-dark;
+	// Primary buttons
+	.button.is-primary {
+		background: $blue-medium;
+		border-color: $blue-wordpress;
 		color: $white;
-	}
-	&[disabled],
-	&:disabled {
-		background: tint( $blue-light, 50% );
-		border-color: tint( $blue-wordpress, 55% );
-		color: $white;
-	}
-	&.is-compact {
-		color: $white;
-	}
-}
 
-// Scary buttons
-.button.is-scary {
-	color: $alert-red;
-
-	&:hover,
-	&:focus {
-		border-color: $alert-red;
-	}
-	&:focus {
-		box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
-	}
-	&[disabled],
-	&:disabled {
-		color: lighten( $alert-red, 30% );
-		border-color: lighten( $gray, 30% );
-	}
-}
-
-.button.is-primary.is-scary {
-	background: $alert-red;
-	border-color: darken( $alert-red, 20% );
-	color: $white;
-
-	&:hover,
-	&:focus {
-		border-color: darken( $alert-red, 40% );
-	}
-	&[disabled],
-	&:disabled {
-		background: lighten( $alert-red, 20% );
-		border-color: tint( $alert-red, 30% );
-	}
-}
-
-.button.is-borderless {
-	border: none;
-	color: darken( $gray, 10% );
-	padding-left: 0;
-	padding-right: 0;
-
-	&:hover {
-		color: $gray-dark;
-	}
-
-	&:focus {
-		box-shadow: none;
-	}
-
-	.gridicon {
-		width: auto;
-		height: auto;
-		top: 6px;
-	}
-
-	&[disabled],
-	&:disabled {
-		color: lighten( $gray, 30% );
-		background: $white;
-		cursor: default;
-
-		&:active {
-			border-width: 0;
+		&:hover,
+		&:focus {
+			border-color: $blue-dark;
+			color: $white;
+		}
+		&[disabled],
+		&:disabled {
+			background: tint( $blue-light, 50% );
+			border-color: tint( $blue-wordpress, 55% );
+			color: $white;
+		}
+		&.is-compact {
+			color: $white;
 		}
 	}
-	&.is-scary {
+
+	// Scary buttons
+	.button.is-scary {
 		color: $alert-red;
 
 		&:hover,
 		&:focus {
-			color: darken( $alert-red, 20% );
+			border-color: $alert-red;
 		}
-
-		&[disabled] {
+		&:focus {
+			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+		}
+		&[disabled],
+		&:disabled {
 			color: lighten( $alert-red, 30% );
+			border-color: lighten( $gray, 30% );
 		}
 	}
 
-	&.is-compact {
-		background: transparent;
-		border-radius: 0;
+	.button.is-primary.is-scary {
+		background: $alert-red;
+		border-color: darken( $alert-red, 20% );
+		color: $white;
+
+		&:hover,
+		&:focus {
+			border-color: darken( $alert-red, 40% );
+		}
+		&[disabled],
+		&:disabled {
+			background: lighten( $alert-red, 20% );
+			border-color: tint( $alert-red, 30% );
+		}
+	}
+
+	.button.is-borderless {
+		border: none;
+		color: darken( $gray, 10% );
+		padding-left: 0;
+		padding-right: 0;
+
+		&:hover {
+			color: $gray-dark;
+		}
+
+		&:focus {
+			box-shadow: none;
+		}
+
 		.gridicon {
-			width: 18px;
-			height: 18px;
-			top: 5px;
+			width: auto;
+			height: auto;
+			top: 6px;
+		}
+
+		&[disabled],
+		&:disabled {
+			color: lighten( $gray, 30% );
+			background: $white;
+			cursor: default;
+
+			&:active {
+				border-width: 0;
+			}
+		}
+		&.is-scary {
+			color: $alert-red;
+
+			&:hover,
+			&:focus {
+				color: darken( $alert-red, 20% );
+			}
+
+			&[disabled] {
+				color: lighten( $alert-red, 30% );
+			}
+		}
+
+		&.is-compact {
+			background: transparent;
+			border-radius: 0;
+			.gridicon {
+				width: 18px;
+				height: 18px;
+				top: 5px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Wrap the button selector in the `wpnc__main` class so that we don’t conflict w/ calypso.