### PR TITLE
Use only system fonts

### DIFF
--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -1,6 +1,6 @@
 .wpnc__note-actions {
 	.wpnc__reply-box {
-		font-family: $serif;
+		font-family: $sans;
 		display: block;
 		position: relative;
 		padding: $padding-medium;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -701,7 +701,7 @@
     }
 
     .wpnc__body .wpnc__body-content .wpnc__paragraph {
-    	font-family: $serif;
+    	font-family: $sans;
     	padding: 0 $padding-large;
     	text-align: left;
     }

--- a/src/boot/stylesheets/shared/typography.scss
+++ b/src/boot/stylesheets/shared/typography.scss
@@ -3,9 +3,6 @@
 $monospace: 'Courier 10 Pitch', Courier, monospace;
 $code: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', $monospace;
 
-$serif-fallback: Georgia, "Times New Roman", Times, serif;
-$serif: 'Noto Serif', $serif-fallback; // 400 400i 700 700i
-
 $sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 $sans-rtl: Tahoma, $sans; // 300 300i 400 400i 600 600i
 


### PR DESCRIPTION
Notifications is the only place we load in custom fonts in the front-end masterbar. We’d like to shift to using system fonts everywhere to avoid loading in that extra font resource.

This PR removes references to our $serif fonts, and replaces them with our $sans (system) font stack.

Screenshot:

**Screenshot:**
<img width="602" alt="screen-shot-2017-04-04-at-7-15-04-am1" src="https://cloud.githubusercontent.com/assets/1202812/25045220/2d09664c-20f9-11e7-8693-dfaee4958994.png">

^ The comments in the left column and the comment reply box were both previously set in Noto, but this PR would make them system fonts like the rest of the UI.

cc @drw158 @dmsnell 