### PR TITLE
Move messaging out of client and expose via top-level props

### DIFF
--- a/doc/public-api.md
+++ b/doc/public-api.md
@@ -23,12 +23,12 @@ Unless we are listening on a WebSocket connection via `pinghub` we want to throt
 <thead>
 <tr>
 <th colspan="2">flags</th>
-<th colspan="2">polling activity</th>
+<th colspan="2">note list polling</th>
 </tr>
 <th><code>isVisible</code></th>
 <th><code>isShowing</code></th>
-<th>list of notes</th>
-<th>content of notes</th>
+<th>meta</th>
+<th>meta + data</th>
 </tr>
 </thead>
 <tbody>

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -3,30 +3,22 @@ import React from 'react';
 
 import Notifications from '../src/Notifications';
 import AuthWrapper from './auth-wrapper';
+import { receiveMessage } from '../src/boot/messaging';
 
 require('../src/boot/stylesheets/style.scss');
 
 const localePattern = /[&?]locale=([\w_-]+)/;
 const match = localePattern.exec(document.location.search);
 const locale = match ? match[1] : 'en';
-let isVisible = true;
-
-const updateVisibility = ({ action, hidden }) => {
-    if ('toggleVisibility' !== action) {
-        return;
-    }
-
-    isVisible = !hidden;
-
-    render();
-};
-
-window.addEventListener('message', updateVisibility);
+let isShowing = true;
 
 const render = () => {
+    const isVisible = document && document.visibilityState === 'visible';
+
     ReactDOM.render(
         React.createElement(AuthWrapper(Notifications), {
             clientId: 52716,
+            isShowing,
             isVisible,
             locale,
             redirectPath: '/',
@@ -35,4 +27,21 @@ const render = () => {
     );
 };
 
-render();
+const init = () => {
+    document && document.addEventListener('visibilitychange', render);
+
+    window &&
+        window.addEventListener(
+            'message',
+            receiveMessage(({ action }) => {
+                if ('togglePanel' === action) {
+                    isShowing = !isShowing;
+                    render();
+                }
+            })
+        );
+
+    render();
+};
+
+init();


### PR DESCRIPTION
This is one step in the process of moving all of our window and document event listeners to the standalone app so that the client may be completely controlled via app props and so that we can completely remove these event handlers from the React app proper.

cc: @gwwar @copons @roundhill @rodrigoi 