### PR TITLE
Fix the gap at the top of the client

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -794,7 +794,8 @@
     	.wpnc__list-view {
     		width: 400px;
     		left: auto;
-    		right: 0px;
+    		right: 0;
+    		top: 0;
 
     		.wpnc__filter {
     			left: auto;


### PR DESCRIPTION
Before:
<img width="399" alt="screen shot 2017-05-01 at 7 16 29 pm" src="https://cloud.githubusercontent.com/assets/789137/25601934/8fd9d906-2ea4-11e7-8f79-55892eaf1f64.png">

After:
<img width="399" alt="screen shot 2017-05-01 at 7 30 01 pm" src="https://cloud.githubusercontent.com/assets/789137/25601938/9deb2f18-2ea4-11e7-8914-3d934d497876.png">

