### PR TITLE
Extract client messages to props instead of postMessage()

### DIFF
--- a/doc/public-api.md
+++ b/doc/public-api.md
@@ -81,11 +81,11 @@ Used to force a manual refresh of the notes from the server.
 
 Indicates that the notifications panel has booted and is ready to receive messages.
 
-### `render` - `onRender() : { unseen: [ { type } ] }`
+### `render` - `onRender() : { unseen: [int] }`
 
 Indicates that the app has rendered and passes along how many new notifications are unseen. Used to set an indicator bell.
 
-### `renderAllSeen` - `onRender() : { unseen: [ { type } ] }`
+### `renderAllSeen` - `onRender() : { unseen: 0 }`
 
 Indicates that the app has rendered all notifications and that there are no unseen notifications. Used to reset an indicator bell.
 

--- a/doc/public-api.md
+++ b/doc/public-api.md
@@ -77,22 +77,22 @@ Used to force a manual refresh of the notes from the server.
 
 ## Signals from App
 
-### `iFrameReady`
+### `iFrameReady` - `onReady() : {}`
 
 Indicates that the notifications panel has booted and is ready to receive messages.
 
-### `render`
+### `render` - `onRender() : { unseen: [ { type } ] }`
 
 Indicates that the app has rendered and passes along how many new notifications are unseen. Used to set an indicator bell.
 
-### `renderAllSeen`
+### `renderAllSeen` - `onRender() : { unseen: [ { type } ] }`
 
 Indicates that the app has rendered all notifications and that there are no unseen notifications. Used to reset an indicator bell.
 
-### `togglePanel`
+### `togglePanel` - `onToggleRequest() : { toggleState: 'open' | 'closed' }`
 
 Indicates a request to close the notifications panel.
 
-### `widescreen`
+### `widescreen` - `onLayoutChange() : { layout: 'narrow' | 'widescreen' }`
 
 Indicates that the app is toggling from narrow to widescreen layouts. Passes along the boolean `widescreen` to indicate which layout is active.

--- a/src/Notifications.jsx
+++ b/src/Notifications.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes, PureComponent } from 'react';
 import { Provider } from 'react-redux';
+import { noop } from 'lodash';
 
 import { store } from './state';
 import actions from './state/actions';
@@ -29,34 +30,44 @@ export class Notifications extends PureComponent {
     static propTypes = {
         isVisible: PropTypes.bool,
         locale: PropTypes.string,
+        onReady: PropTypes.func,
+        onRender: PropTypes.func,
+        onToggleRequest: PropTypes.func,
+        onLayoutChange: PropTypes.func,
+        receiveMessage: PropTypes.func,
         wpcom: PropTypes.object.isRequired,
     };
 
     static defaultProps = {
         isVisible: false,
         locale: 'en',
-        receiveMessage: () => {},
+        onReady: noop,
+        onRender: noop,
+        onToggleRequest: noop,
+        onLayoutChange: noop,
+        receiveMessage: noop,
     };
 
     componentWillMount() {
         const {
             isShowing,
             isVisible,
+            onRender,
             receiveMessage,
             wpcom,
         } = this.props;
 
         initAPI(wpcom);
 
-        client = new RestClient();
+        client = new RestClient({ onRender });
         client.global = globalData;
         client.sendMessage = receiveMessage;
 
-        // Send iFrameReady message as soon as we're loaded
-        // (innocuous if we're not actually in an iframe)
-        client.sendMessage({ action: 'iFrameReady' });
-
         client.setVisibility({ isShowing, isVisible });
+    }
+
+    componentDidMount() {
+        this.props.onReady();
     }
 
     componentWillReceiveProps({ isShowing, isVisible, wpcom }) {

--- a/src/rest-client/index.js
+++ b/src/rest-client/index.js
@@ -22,7 +22,9 @@ const settings = {
     max_limit: 100,
 };
 
-export function Client() {
+export function Client({ onRender }) {
+    this.onRender = onRender;
+
     this.noteList = [];
     this.gettingNotes = false;
     this.timeout = false;
@@ -160,7 +162,7 @@ function getNote(note_id) {
             return;
         }
         store.dispatch(actions.notes.addNotes(data.notes));
-        this.ready();
+        ready.call(this);
     });
 }
 
@@ -312,10 +314,9 @@ function ready() {
 
     debug('ready: %d new notes, lastSeenTime: %s', newNoteCount, this.lastSeenTime);
 
-    this.sendMessage({
-        action: 'render',
-        num_new: newNoteCount,
-        latest_type: get(notes.slice(-1)[0], 'type', null),
+    this.onRender({
+        unseen: newNoteCount,
+        latestType: get(notes.slice(-1)[0], 'type', null),
     });
 
     this.hasNewNoteData = false;
@@ -444,9 +445,7 @@ function handleStorageEvent(event) {
         try {
             const lastSeenTime = Number(event.newValue);
             if (updateLastSeenTime.call(this, lastSeenTime, true)) {
-                this.sendMessage({
-                    action: 'renderAllSeen',
-                });
+                this.onRender({ unseen: 0 });
             }
         } catch (e) {}
     }

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -13,6 +13,16 @@ const locale = match ? match[1] : 'en';
 let isShowing = true;
 let isVisible = document.visibilityState === 'visible';
 
+const onReady = () => sendMessage({ action: 'iFrameReady' });
+const onRender = ({ latestType, unseen }) =>
+    unseen > 0
+        ? sendMessage({
+              action: 'render',
+              num_new: unseen,
+              latest_type: latestType,
+          })
+        : sendMessage({ action: 'renderAllSeen' });
+
 const render = () => {
     ReactDOM.render(
         React.createElement(AuthWrapper(Notifications), {
@@ -20,6 +30,8 @@ const render = () => {
             isShowing,
             isVisible,
             locale,
+            onReady,
+            onRender,
             receiveMessage: sendMessage,
             redirectPath: '/',
         }),


### PR DESCRIPTION
Previously we were sending `ready` and `render` type messages from the
rest client to the parent window with `postMessage()`. Now we send these
messages via a passed in `onReady` and `onRender` prop to the app.

cc: @gwwar @roundhill @rodrigoi @Copons 