### PR TITLE
CSS: Fix the back button arrow alignment

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -794,7 +794,8 @@
     	.wpnc__list-view {
     		width: 400px;
     		left: auto;
-    		right: 0px;
+    		right: 0;
+    		top: 0;
 
     		.wpnc__filter {
     			left: auto;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -81,6 +81,7 @@
     			@extend %wpnc__noticon;
     			content: '\f431';
     			transform: rotate( 90deg );
+    			vertical-align: middle;
     		}
     	}
 


### PR DESCRIPTION
Before:
<img width="79" alt="screen shot 2017-05-02 at 11 18 09 am" src="https://cloud.githubusercontent.com/assets/789137/25632766/c286d3ec-2f29-11e7-90c5-2c0959c1b2ee.png">

After:
<img width="99" alt="screen shot 2017-05-02 at 11 17 48 am" src="https://cloud.githubusercontent.com/assets/789137/25632775/ca2b195a-2f29-11e7-92b1-84a7c7ef16c9.png">
