### PR TITLE
Use older Redux store enhancer API

### DIFF
--- a/src/Notifications.jsx
+++ b/src/Notifications.jsx
@@ -29,6 +29,7 @@ export const refreshNotes = () => client && client.refreshNotes.call(client);
 
 export class Notifications extends PureComponent {
     static propTypes = {
+        isShowing: PropTypes.bool,
         isVisible: PropTypes.bool,
         locale: PropTypes.string,
         onReady: PropTypes.func,

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -13,9 +13,9 @@ const reducer = combineReducers({
 
 /** @see https://github.com/zalmoxisus/redux-devtools-extension */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const withMiddleware = composeEnhancers(applyMiddleware(actionMiddleware))(createStore);
 
-export const store = createStore(
+export const store = withMiddleware(
     reducer,
-    reducer(undefined, { type: '@@INIT' }),
-    composeEnhancers(applyMiddleware(actionMiddleware))
+    reducer(undefined, { type: '@@INIT' })
 );


### PR DESCRIPTION
Although the newer API version is cleaner, Calypso still uses redux@<3.1
where the new API was introduced. The newer versions of Redux still
allow for this old syntax so this change uses the common denominator
where it will work in both places.

Previously the middleware simply didn't load in Calypso

@Automattic/lannister @apeatling @gwwar 