### PR TITLE
Change id to className

### DIFF
--- a/src/templates/empty-message.jsx
+++ b/src/templates/empty-message.jsx
@@ -26,7 +26,7 @@ export const EmptyMessage = React.createClass({
         var message;
         if (this.props.link && this.props.linkMessage) {
             message = (
-                <div id="wpnc__empty-notes">
+                <div className="wpnc__empty-notes">
                     <h2>{this.props.emptyMessage}</h2>
                     <p>
                         <a href={this.props.link} target="_blank" onClick={this.handleClick}>
@@ -44,7 +44,7 @@ export const EmptyMessage = React.createClass({
             );
         } else {
             message = (
-                <div id="wpnc__empty-notes">
+                <div className="wpnc__empty-notes">
                     <h2>{this.props.emptyMessage}</h2>
                 </div>
             );


### PR DESCRIPTION
In the css, this was being written as a class, so no styles were being
applied. There’s no reason not to make it a class, as far as I can tell.

To test: click on the Unread filter (make sure you have read all of your notes).

After:

<img width="423" alt="screen shot 2017-05-02 at 5 59 02 pm" src="https://cloud.githubusercontent.com/assets/618551/25645245/0b38912a-2f61-11e7-9f47-6fd4b5df85ea.png">
