### PR TITLE
Stop remounting on update

### DIFF
--- a/src/Notifications.jsx
+++ b/src/Notifications.jsx
@@ -29,6 +29,7 @@ export const refreshNotes = () => client && client.refreshNotes.call(client);
 
 export class Notifications extends PureComponent {
     static propTypes = {
+        appUpdater: PropTypes.func,
         isShowing: PropTypes.bool,
         isVisible: PropTypes.bool,
         locale: PropTypes.string,
@@ -41,6 +42,7 @@ export class Notifications extends PureComponent {
     };
 
     static defaultProps = {
+        appUpdater: noop,
         isVisible: false,
         locale: 'en',
         onReady: noop,
@@ -52,6 +54,7 @@ export class Notifications extends PureComponent {
 
     componentWillMount() {
         const {
+            appUpdater,
             isShowing,
             isVisible,
             onRender,
@@ -59,6 +62,8 @@ export class Notifications extends PureComponent {
             receiveMessage,
             wpcom,
         } = this.props;
+
+        appUpdater(() => this.forceUpdate());
 
         initAPI(wpcom);
         initPublicAPI({ onTogglePanel });

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -26,9 +26,13 @@ const onRender = ({ latestType, unseen }) =>
 
 const onTogglePanel = () => sendMessage({ action: 'togglePanel' });
 
+let refresh = () => {};
+const appUpdater = f => refresh = f;
+
 const render = () => {
     ReactDOM.render(
         React.createElement(AuthWrapper(Notifications), {
+            appUpdater,
             clientId: 52716,
             isShowing,
             isVisible,
@@ -44,19 +48,21 @@ const render = () => {
 };
 
 const init = () => {
-    document.addEventListener('visibilitychange', render);
+    render();
+
+    document.addEventListener('visibilitychange', refresh);
 
     window.addEventListener(
         'message',
         receiveMessage(({ action, hidden, showing }) => {
             if ('togglePanel' === action) {
                 isShowing = showing;
-                render();
+                refresh();
             }
 
             if ('toggleVisibility' === action) {
                 isVisible = !hidden;
-                render();
+                refresh();
             }
         })
     );
@@ -69,8 +75,6 @@ const init = () => {
             }
         })
     );
-
-    render();
 };
 
 init();


### PR DESCRIPTION
With the standalone app we were rerendering the main app component every
time an external change demanded a repaint. Now we're passing in a
callback to accept an updater function (this.forceUpdate in disguise)
and calling that instead of rerendering the whole thing.

This was all my fault. Sorry.

cc: @Automattic/lannister @gwwar @apeatling 