### PR TITLE
Add Sticky Headers

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -176,7 +176,6 @@ body {
     	border-bottom: 1px solid lighten( $gray, 30 );
     	text-align: center; // Center filter in IE 9
     	height: $filter-height;
-    	z-index: 10;
     	box-sizing: border-box;
     	direction: ltr;
     	display: table; //fallback for browsers not supporting flexbox
@@ -457,9 +456,6 @@ body {
         z-index: 100;
     		text-align: left;
         position: -webkit-sticky;
-        position: -moz-sticky;
-        position: -ms-sticky;
-        position: -o-sticky;
         position: sticky;
     	}
     }

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -339,6 +339,7 @@ body {
     }
 
     .wpnc__list-view {
+    	height: 100%;
     	background-color: $gray-light;
     	overflow-y: scroll;
     	-webkit-overflow-scrolling: touch;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -45,11 +45,6 @@ body {
     }
 
     header {
-    	position: fixed;
-    	z-index: 10;
-    	top: 0px;
-    	left: 0px;
-    	right: 0px;
     	border-bottom: 1px solid lighten( $gray, 30 );
     	box-sizing: border-box;
     	background-color: $white;
@@ -248,10 +243,6 @@ body {
 
     .wpnc__list-view .wpnc__notes, .error {
     	background-color: $white;
-    }
-
-    .wpnc__single-view .wpnc__note {
-    	margin-top: $title-bar-height;
     }
 
     .wpnc__note {
@@ -506,15 +497,17 @@ body {
 
     .wpnc__single-view {
     	position: absolute;
+      display: flex;
+      flex-direction: column;
     	height: 100%;
     	left: 0px;
     	right: 0px;
-    	overflow-y: scroll;
-    	-webkit-overflow-scrolling: touch;
 
     	background-color: $gray-light;
     	ol {
     		background-color: $white;
+        overflow-y: scroll;
+      	-webkit-overflow-scrolling: touch;
     	}
 
     	.wpnc__action-link {
@@ -810,8 +803,6 @@ body {
     		border-left: 1px solid lighten( $gray, 30 );
 
     		header {
-    			position: relative;
-
     			nav {
     				display: none;
     			}

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -452,6 +452,10 @@ body {
     	}
     }
 
+    .disable-sticky .wpnc__time-group-wrap {
+      position: static;
+    }
+
     .wpnc__undo-item {
     	background: $alert-red;
     	color: $white;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -170,18 +170,16 @@ body {
     }
 
     .wpnc__filter {
+      width: 100%;
     	background-color: $white;
     	color: $gray;
     	border-bottom: 1px solid lighten( $gray, 30 );
     	text-align: center; // Center filter in IE 9
-    	position: fixed;
-    	top: 0;
     	height: $filter-height;
     	z-index: 10;
     	box-sizing: border-box;
     	direction: ltr;
     	display: table; //fallback for browsers not supporting flexbox
-    	width: 100%;
 
     	@media only screen and (min-width: 409px) and (max-width: 430px) {
     		left: 10px;
@@ -250,7 +248,6 @@ body {
     }
 
     .wpnc__list-view .wpnc__notes, .error {
-    	margin-top: $title-offset;
     	background-color: $white;
     }
 
@@ -335,14 +332,26 @@ body {
     	height: 90px;
     }
 
+    .wpnc__note-list {
+      position: absolute;
+      display: flex;
+      flex-direction: column;
+      top: 0;
+    	right: 0;
+    	left: auto;
+      bottom: 0;
+      width: 400px;
+      overflow: hidden;
+
+      @media only screen and (max-width: 799px) {
+  			width: 100%;
+  		}
+    }
+
     .wpnc__list-view {
     	background-color: $gray-light;
     	overflow-y: scroll;
     	-webkit-overflow-scrolling: touch;
-    	position: absolute;
-    	height: 100%;
-    	right: 0px;
-    	left: 0px;
     	border-left: 1px solid lighten( $gray, 30 );
     	box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
 
@@ -440,19 +449,18 @@ body {
     			margin-top: 3px;
     			padding-left: $padding-medium;
     		}
-
-    	}
-
-    	.wpnc__time-group-title.fixed {
-    		position: fixed;
-    		z-index: 1;
-    		top: $title-offset;
-    		width: 100%;
     	}
 
     	.wpnc__time-group-wrap {
     		height: $header-height;
+        top: 0;
+        z-index: 100;
     		text-align: left;
+        position: -webkit-sticky;
+        position: -moz-sticky;
+        position: -ms-sticky;
+        position: -o-sticky;
+        position: sticky;
     	}
     }
 
@@ -794,19 +802,6 @@ body {
     		}
 
     		box-shadow: none;
-    	}
-
-    	.wpnc__list-view {
-    		width: 400px;
-    		left: auto;
-    		right: 0;
-    		top: 0;
-
-    		.wpnc__filter {
-    			left: auto;
-    			right: 0px;
-    			width: 400px;
-    		}
     	}
 
     	.wpnc__single-view {

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -15,7 +15,4 @@ const reducer = combineReducers({
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const withMiddleware = composeEnhancers(applyMiddleware(actionMiddleware))(createStore);
 
-export const store = withMiddleware(
-    reducer,
-    reducer(undefined, { type: '@@INIT' })
-);
+export const store = withMiddleware(reducer, reducer(undefined, { type: '@@INIT' }));

--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -461,7 +461,7 @@ const Layout = React.createClass({
         const filteredNotes = this.filterController.getFilteredNotes(this.props.notes);
 
         return (
-            <div>
+            <div style={{ width: document.body.clientWidth }}>
                 {this.props.error && <AppError error={this.props.error} />}
 
                 {!this.props.error &&

--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -461,7 +461,7 @@ const Layout = React.createClass({
         const filteredNotes = this.filterController.getFilteredNotes(this.props.notes);
 
         return (
-            <div style={{ width: document.body.clientWidth }}>
+            <div>
                 {this.props.error && <AppError error={this.props.error} />}
 
                 {!this.props.error &&

--- a/src/templates/list-header.jsx
+++ b/src/templates/list-header.jsx
@@ -13,17 +13,7 @@ const ListHeader = React.createClass({
     getDefaultProps: function() {
         return {
             title: 'None',
-            index: -1,
-            offset: -1,
-            nextOffset: -1,
         };
-    },
-
-    componentDidUpdate: function() {
-        var node = ReactDOM.findDOMNode(this);
-        if (node.offsetTop != this.props.offset && node.offsetTop > 0) {
-            this.props.setOffset(this.props.index, node.offsetTop);
-        }
     },
 
     render: function() {

--- a/src/templates/list-header.jsx
+++ b/src/templates/list-header.jsx
@@ -1,34 +1,11 @@
-import ReactDOM from 'react-dom';
 import React from 'react';
 
-var debug = require('debug')('notifications:list-header');
-
-// from $title-offset in boot/sizes.scss
-var TITLE_OFFSET = 38;
-
-// from $header-height in boot/sizes.scss
-var HEADER_HEIGHT = 34;
-
-const ListHeader = React.createClass({
-    getDefaultProps: function() {
-        return {
-            title: 'None',
-        };
-    },
-
-    render: function() {
-        //		var debugLine = this.props.title + "  offset:" + this.props.offset + " scroll:" + this.props.scroll + " nextOffset: " + this.props.nextOffset + " index:" + this.props.index;
-        var title = this.props.title, classNames = ['wpnc__time-group-title'], style = {};
-        classNames = classNames.join(' ');
-
-        return (
-            <li className="wpnc__time-group-wrap">
-                <div className={classNames} style={style}>
-                    <span className="wpnc__noticon noticon-time" />{title}
-                </div>
-            </li>
-        );
-    },
-});
+export const ListHeader = ({ title = 'None' }) => (
+    <li className="wpnc__time-group-wrap">
+        <div className="wpnc__time-group-title">
+            <span className="wpnc__noticon noticon-time" />{title}
+        </div>
+    </li>
+);
 
 export default ListHeader;

--- a/src/templates/list-header.jsx
+++ b/src/templates/list-header.jsx
@@ -29,32 +29,6 @@ const ListHeader = React.createClass({
     render: function() {
         //		var debugLine = this.props.title + "  offset:" + this.props.offset + " scroll:" + this.props.scroll + " nextOffset: " + this.props.nextOffset + " index:" + this.props.index;
         var title = this.props.title, classNames = ['wpnc__time-group-title'], style = {};
-
-        /*if (this.props.offset != -1 && this.props.nextOffset != -1) {
-            if (
-                this.props.scroll >= this.props.offset - TITLE_OFFSET &&
-                this.props.scroll < this.props.nextOffset - (HEADER_HEIGHT + TITLE_OFFSET)
-            ) {
-                classNames.push('fixed');
-            }
-            if (
-                this.props.scroll >= this.props.nextOffset - (HEADER_HEIGHT + TITLE_OFFSET) &&
-                this.props.scroll < this.props.nextOffset - TITLE_OFFSET
-            ) {
-                classNames.push('fixed');
-                style = {
-                    position: 'absolute',
-                    top: this.props.nextOffset - HEADER_HEIGHT + 'px',
-                };
-            }
-        } else if (this.props.offset != -1) {
-            if (
-                this.props.scroll >= this.props.offset - TITLE_OFFSET &&
-                this.props.offset >= TITLE_OFFSET
-            ) {
-                classNames.push('fixed');
-            }
-        }*/
         classNames = classNames.join(' ');
 
         return (

--- a/src/templates/list-header.jsx
+++ b/src/templates/list-header.jsx
@@ -30,7 +30,7 @@ const ListHeader = React.createClass({
         //		var debugLine = this.props.title + "  offset:" + this.props.offset + " scroll:" + this.props.scroll + " nextOffset: " + this.props.nextOffset + " index:" + this.props.index;
         var title = this.props.title, classNames = ['wpnc__time-group-title'], style = {};
 
-        if (this.props.offset != -1 && this.props.nextOffset != -1) {
+        /*if (this.props.offset != -1 && this.props.nextOffset != -1) {
             if (
                 this.props.scroll >= this.props.offset - TITLE_OFFSET &&
                 this.props.scroll < this.props.nextOffset - (HEADER_HEIGHT + TITLE_OFFSET)
@@ -54,7 +54,7 @@ const ListHeader = React.createClass({
             ) {
                 classNames.push('fixed');
             }
-        }
+        }*/
         classNames = classNames.join(' ');
 
         return (

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -50,8 +50,6 @@ export const NoteList = React.createClass({
     },
 
     componentWillMount: function() {
-        this.offsets = [-1, -1, -1, -1, -1];
-
         this.props.global.updateStatusBar = this.updateStatusBar;
         this.props.global.resetStatusBar = this.resetStatusBar;
         this.props.global.updateUndoBar = this.updateUndoBar;
@@ -118,11 +116,6 @@ export const NoteList = React.createClass({
 
     onScrollEnd() {
         this.setState({ scrolling: false });
-    },
-
-    setOffset: function(index, offset) {
-        if (index < 0 || index >= this.offsets.length) return;
-        this.offsets[index] = offset;
     },
 
     updateStatusBar: function(message, classList, delay) {
@@ -305,36 +298,15 @@ export const NoteList = React.createClass({
 
         var header;
         var nextOffset;
-        var offset_i;
-        var scroll;
-        var offsets = this.offsets;
 
         /* Build a single list of notes, undo bars, and time group headers */
         var notes = noteGroups.reduce(
             function(notes, group, i) {
                 if (0 < group.length) {
-                    if (_this.state && _this.state.scrollY) {
-                        scroll = _this.state.scrollY;
-                    } else {
-                        scroll = 0;
-                    }
-                    // find next header that has an offset (not all headers may
-                    // be displayed)
-                    offset_i = i + 1;
-                    while (offsets[offset_i] == -1 && offset_i < offsets.length) {
-                        offset_i += 1;
-                    }
-                    nextOffset = offsets[offset_i];
-
                     header = (
                         <ListHeader
                             key={'time-group-' + i}
                             title={_this.groupTitles[i]}
-                            scroll={scroll}
-                            index={i}
-                            offset={offsets[i]}
-                            nextOffset={nextOffset}
-                            setOffset={_this.setOffset}
                         />
                     );
                     notes.push(header);

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -61,11 +61,11 @@ export const NoteList = React.createClass({
     },
 
     componentDidMount() {
-        ReactDOM.findDOMNode(this).addEventListener('scroll', this.onScroll);
+        ReactDOM.findDOMNode(this.scrollableContainer).addEventListener('scroll', this.onScroll);
     },
 
     componentWillUnmount: function() {
-        ReactDOM.findDOMNode(this).removeEventListener('scroll', this.onScroll);
+        ReactDOM.findDOMNode(this.scrollableContainer).removeEventListener('scroll', this.onScroll);
     },
 
     componentWillReceiveProps: function(nextProps) {
@@ -77,7 +77,7 @@ export const NoteList = React.createClass({
 
     componentDidUpdate: function(prevProps) {
         if (this.noteList && !this.props.isLoading) {
-            var element = ReactDOM.findDOMNode(this);
+            var element = ReactDOM.findDOMNode(this.scrollableContainer);
             var notes = this.noteList;
             if (
                 element.clientHeight > 0 &&
@@ -97,11 +97,11 @@ export const NoteList = React.createClass({
             return;
         }
 
-        this.isSrolling = true;
+        this.isScrolling = true;
 
-        requestAnimationFrame(() => this.isSrolling = false);
+        requestAnimationFrame(() => this.isScrolling = false);
 
-        const element = ReactDOM.findDOMNode(this);
+        const element = ReactDOM.findDOMNode(this.scrollableContainer);
         if (!this.state.scrolling || this.state.scrollY !== element.scrollTop) {
             // only set state and trigger render if something has changed
             this.setState({
@@ -198,6 +198,10 @@ export const NoteList = React.createClass({
 
     storeNoteList(ref) {
         this.noteList = ref;
+    },
+
+    storeScrollableContainer(ref) {
+        this.scrollableContainer = ref;
     },
 
     storeUndoActImmediately(actImmediately) {
@@ -352,6 +356,7 @@ export const NoteList = React.createClass({
             <div className={classes}>
                 <FilterBar controller={this.props.filterController} />
                 <div
+                    ref={this.storeScrollableContainer}
                     className={
                         this.props.selectedNoteId
                             ? 'wpnc__list-view wpnc__current'

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -303,12 +303,7 @@ export const NoteList = React.createClass({
         var notes = noteGroups.reduce(
             function(notes, group, i) {
                 if (0 < group.length) {
-                    header = (
-                        <ListHeader
-                            key={'time-group-' + i}
-                            title={_this.groupTitles[i]}
-                        />
-                    );
+                    header = <ListHeader key={'time-group-' + i} title={_this.groupTitles[i]} />;
                     notes.push(header);
                     notes.push.apply(notes, group);
                 }
@@ -349,35 +344,40 @@ export const NoteList = React.createClass({
             );
         }
 
-        const classes = classNames( 'wpnc__note-list', {
-          'disable-sticky': !! window.chrome && !! window.chrome.webstore, // position: sticky doesn't work in Chrome
-        } );
+        const classes = classNames('wpnc__note-list', {
+            'disable-sticky': !!window.chrome && !!window.chrome.webstore, // position: sticky doesn't work in Chrome
+        });
 
         return (
-            <div className={ classes }>
-              <FilterBar controller={this.props.filterController} />
-              <div
-                  className={
-                      this.props.selectedNoteId ? 'wpnc__list-view wpnc__current' : 'wpnc__list-view'
-                  }
-              >
-                  <ol ref={this.storeNoteList} className="wpnc__notes">
-                      <StatusBar
-                          statusClasses={this.state.statusClasses}
-                          statusMessage={this.state.statusMessage}
-                          statusTimeout={this.state.statusTimeout}
-                          statusReset={this.resetStatusBar}
-                      />
-                      {notes}
-                      {this.props.isLoading &&
-                          <div style={loadingIndicatorVisibility} className="wpnc__loading-indicator">
-                              <div className="spinner animated">
-                                  <span className="side left" />
-                                  <span className="side right" />
-                              </div>
-                          </div>}
-                  </ol>
-              </div>
+            <div className={classes}>
+                <FilterBar controller={this.props.filterController} />
+                <div
+                    className={
+                        this.props.selectedNoteId
+                            ? 'wpnc__list-view wpnc__current'
+                            : 'wpnc__list-view'
+                    }
+                >
+                    <ol ref={this.storeNoteList} className="wpnc__notes">
+                        <StatusBar
+                            statusClasses={this.state.statusClasses}
+                            statusMessage={this.state.statusMessage}
+                            statusTimeout={this.state.statusTimeout}
+                            statusReset={this.resetStatusBar}
+                        />
+                        {notes}
+                        {this.props.isLoading &&
+                            <div
+                                style={loadingIndicatorVisibility}
+                                className="wpnc__loading-indicator"
+                            >
+                                <div className="spinner animated">
+                                    <span className="side left" />
+                                    <span className="side right" />
+                                </div>
+                            </div>}
+                    </ol>
+                </div>
             </div>
         );
     },

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -377,28 +377,30 @@ export const NoteList = React.createClass({
         }
 
         return (
-            <div
-                className={
-                    this.props.selectedNoteId ? 'wpnc__list-view wpnc__current' : 'wpnc__list-view'
-                }
-            >
-                <FilterBar controller={this.props.filterController} />
-                <ol ref={this.storeNoteList} className="wpnc__notes">
-                    <StatusBar
-                        statusClasses={this.state.statusClasses}
-                        statusMessage={this.state.statusMessage}
-                        statusTimeout={this.state.statusTimeout}
-                        statusReset={this.resetStatusBar}
-                    />
-                    {notes}
-                    {this.props.isLoading &&
-                        <div style={loadingIndicatorVisibility} className="wpnc__loading-indicator">
-                            <div className="spinner animated">
-                                <span className="side left" />
-                                <span className="side right" />
-                            </div>
-                        </div>}
-                </ol>
+            <div className="wpnc__note-list">
+              <FilterBar controller={this.props.filterController} />
+              <div
+                  className={
+                      this.props.selectedNoteId ? 'wpnc__list-view wpnc__current' : 'wpnc__list-view'
+                  }
+              >
+                  <ol ref={this.storeNoteList} className="wpnc__notes">
+                      <StatusBar
+                          statusClasses={this.state.statusClasses}
+                          statusMessage={this.state.statusMessage}
+                          statusTimeout={this.state.statusTimeout}
+                          statusReset={this.resetStatusBar}
+                      />
+                      {notes}
+                      {this.props.isLoading &&
+                          <div style={loadingIndicatorVisibility} className="wpnc__loading-indicator">
+                              <div className="spinner animated">
+                                  <span className="side left" />
+                                  <span className="side right" />
+                              </div>
+                          </div>}
+                  </ol>
+              </div>
             </div>
         );
     },

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -2,6 +2,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 import actions from '../state/actions';
 import getIsLoading from '../state/selectors/get-is-loading';
@@ -376,8 +377,12 @@ export const NoteList = React.createClass({
             );
         }
 
+        const classes = classNames( 'wpnc__note-list', {
+          'disable-sticky': !! window.chrome && !! window.chrome.webstore, // position: sticky doesn't work in Chrome
+        } );
+
         return (
-            <div className="wpnc__note-list">
+            <div className={ classes }>
               <FilterBar controller={this.props.filterController} />
               <div
                   className={


### PR DESCRIPTION
Removes the js based sticky headers and replaces it with `position: sticky`. Unfortunately, Chrome doesn't seem to support sticky headers with a fixed position parent, so we've added a browser check for it in order to disable the stickies.