### PR TITLE
Fix detail view scroll position after HTML changes

### DIFF
--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -90,8 +90,8 @@ const Layout = React.createClass({
         return {
             lastSelectedIndex: 0,
             navigationEnabled: true,
+            previousDetailScrollTop: 0,
             previouslySelectedNoteId: null,
-            previouslySelectedNoteScrollTop: 0,
             selectedNote: null,
         };
     },
@@ -129,8 +129,8 @@ const Layout = React.createClass({
     componentWillReceiveProps: function(nextProps) {
         if (this.props.selectedNoteId) {
             this.setState({
+                previousDetailScrollTop: this.detailView ? this.detailView.scrollTop : 0,
                 previouslySelectedNoteId: this.props.selectedNoteId,
-                previouslySelectedNoteScrollTop: this.detailView ? this.detailView.scrollTop : 0,
             });
         }
 
@@ -192,16 +192,11 @@ const Layout = React.createClass({
         if (!this.detailView) {
             return;
         }
-        const {
-            previouslySelectedNoteId,
-            previouslySelectedNoteScrollTop,
-            selectedNote,
-        } = this.state;
-        if (selectedNote !== previouslySelectedNoteId) {
-            this.detailView.scrollTop = 0;
-        } else {
-            this.detailView.scrollTop = previouslySelectedNoteScrollTop;
-        }
+        const { previousDetailScrollTop, previouslySelectedNoteId, selectedNote } = this.state;
+
+        this.detailView.scrollTop = selectedNote === previouslySelectedNoteId
+            ? previousDetailScrollTop
+            : 0;
     },
 
     componentWillUnmount: function() {

--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -197,17 +197,9 @@ const Layout = React.createClass({
             previouslySelectedNoteScrollTop,
             selectedNote,
         } = this.state;
-        console.log({
-            previouslySelectedNoteId,
-            previouslySelectedNoteScrollTop,
-            selectedNote,
-            detailView: this.detailView,
-        });
         if (selectedNote !== previouslySelectedNoteId) {
-            console.log('scrolled to top');
             this.detailView.scrollTop = 0;
         } else {
-            console.log('scrolled to pos');
             this.detailView.scrollTop = previouslySelectedNoteScrollTop;
         }
     },

--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -91,6 +91,7 @@ const Layout = React.createClass({
             lastSelectedIndex: 0,
             navigationEnabled: true,
             previouslySelectedNoteId: null,
+            previouslySelectedNoteScrollTop: 0,
             selectedNote: null,
         };
     },
@@ -129,6 +130,7 @@ const Layout = React.createClass({
         if (this.props.selectedNoteId) {
             this.setState({
                 previouslySelectedNoteId: this.props.selectedNoteId,
+                previouslySelectedNoteScrollTop: this.detailView ? this.detailView.scrollTop : 0,
             });
         }
 
@@ -187,9 +189,26 @@ const Layout = React.createClass({
     },
 
     componentDidUpdate: function() {
-        const { previouslySelectedNoteId, selectedNote } = this.state;
-        if (this.detailView && selectedNote !== previouslySelectedNoteId) {
+        if (!this.detailView) {
+            return;
+        }
+        const {
+            previouslySelectedNoteId,
+            previouslySelectedNoteScrollTop,
+            selectedNote,
+        } = this.state;
+        console.log({
+            previouslySelectedNoteId,
+            previouslySelectedNoteScrollTop,
+            selectedNote,
+            detailView: this.detailView,
+        });
+        if (selectedNote !== previouslySelectedNoteId) {
+            console.log('scrolled to top');
             this.detailView.scrollTop = 0;
+        } else {
+            console.log('scrolled to pos');
+            this.detailView.scrollTop = previouslySelectedNoteScrollTop;
         }
     },
 
@@ -497,7 +516,6 @@ const Layout = React.createClass({
                     />}
 
                 <div
-                    ref={this.storeDetailViewRef}
                     className={
                         currentNote ? 'wpnc__single-view wpnc__current' : 'wpnc__single-view'
                     }
@@ -534,7 +552,7 @@ const Layout = React.createClass({
                         </header>}
 
                     {currentNote &&
-                        <ol>
+                        <ol ref={this.storeDetailViewRef}>
                             <Note
                                 key={'note-' + currentNote.id}
                                 client={this.props.client}


### PR DESCRIPTION
Previously the detail view scrollbar was on its root element.
It was moved to the `<ol>` rendering #38 futile.

While the main element has a `max-height: 100%`, making keeping the scroll position an automatic task, the constantly changing list height introduces the need to keeping track of the scroll position when closing the detail view.

This PR moves the ref to the correct element and stores the detail view list scroll position.
The scroll position will be used again if the same note is opened again immediately.