### PR TITLE
Stop sending the widescreen message twice

### DIFF
--- a/src/state/action-middleware/ui/index.js
+++ b/src/state/action-middleware/ui/index.js
@@ -41,15 +41,10 @@ export const togglePanel = (store, { type }) => {
     onTogglePanel({ toggleState });
 };
 
-export const updateLayout = (store, { selectedNote }) => {
-    onLayoutChange({ layout: selectedNote ? 'widescreen' : 'narrow' });
-};
-
 export default {
     [types.CLOSE_PANEL]: [togglePanel],
     [types.SPAM_NOTE]: [advanceToNextNote],
     [types.OPEN_PANEL]: [togglePanel],
-    [types.SELECT_NOTE]: [updateLayout],
     [types.SET_LAYOUT]: [announceLayoutChange],
     [types.TRASH_NOTE]: [advanceToNextNote],
 };


### PR DESCRIPTION
It's already being send by `note-list.jsx` when a note is selected and therefore we don't need to fire it off in middleware on selecting a note as well. This was causing the drawer to not slide out.

cc: @Automattic/lannister @gwwar @apeatling 