### PR TITLE
Notifications: resolve suggestions typo

### DIFF
--- a/src/suggestions/index.jsx
+++ b/src/suggestions/index.jsx
@@ -267,7 +267,7 @@ export const SuggestionsMixin = {
             return;
         }
 
-        this.suggestsionsMixin_suggestionNodes = {
+        this.suggestionsMixin_suggestionNodes = {
             ...this.suggestionsMixin_suggestionNodes,
             [ref.props['data-suggestion-id']]: ref,
         };


### PR DESCRIPTION
There was a typo in `suggestionsMixin_suggestionNodes` that prevented
`ensureSelectedSuggestionVisibility` from executing past first bail,
and reaching the scroll functionality.