### PR TITLE
Remove the scrollbar when unnecessary

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -510,8 +510,8 @@ body {
 
     	background-color: $gray-light;
     	ol {
-    		background-color: $white;
-        overflow-y: scroll;
+				height: 100%;
+        overflow-y: auto;
       	-webkit-overflow-scrolling: touch;
     	}
 
@@ -595,6 +595,7 @@ body {
     	}
 
     	.wpnc__note {
+				background-color: $white;
     		border: none;
     	}
 


### PR DESCRIPTION
Only show the detail view scrollbar if actually needed.

@drw158 in the end I've left the `:after { content: "."; }` because long notes looks better with that bit of bottom spacing.

## Screenshots

Really short note:

<img width="409" alt="screen shot 2017-05-03 at 16 34 45" src="https://cloud.githubusercontent.com/assets/2070010/25685850/0640645e-301f-11e7-83d7-a1f217e6c5fa.png">

Short note with reply box:

<img width="411" alt="screen shot 2017-05-03 at 16 35 12" src="https://cloud.githubusercontent.com/assets/2070010/25685852/065b7ffa-301f-11e7-9c5c-db8c9c386388.png">

Super long note:

<img width="407" alt="screen shot 2017-05-03 at 16 35 04" src="https://cloud.githubusercontent.com/assets/2070010/25685851/0641689a-301f-11e7-8205-ef9d1607bff4.png">
