### PR TITLE
Add an .editorconfig file to keep the editors automatic choices consistent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Introduce an `.editorconfig` file to keep the editors automatic choices consistent (looking at you, Atom!).

It takes as a base Calypso's [`.editorconfig`](https://github.com/Automattic/wp-calypso/blob/master/.editorconfig):

```ini
# http://editorconfig.org
root = true

[*]
# http://editorconfig.org
root = true

[*]
indent_style = tab
end_of_line = lf
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true

[*.md]
trim_trailing_whitespace = false
```

But it changes the indent style to 4 spaces instead of a tab to be consistent with Prettier.