### PR TITLE
Add a shadow to the notification list

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -332,6 +332,9 @@ body {
       bottom: 0;
       width: 400px;
       overflow: hidden;
+			&:not(.is-note-open) {
+				box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
+			}
 
       @media only screen and (max-width: 799px) {
   			width: 100%;

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -99,7 +99,7 @@ export const NoteList = React.createClass({
 
         this.isScrolling = true;
 
-        requestAnimationFrame(() => this.isScrolling = false);
+        requestAnimationFrame(() => (this.isScrolling = false));
 
         const element = ReactDOM.findDOMNode(this.scrollableContainer);
         if (!this.state.scrolling || this.state.scrollY !== element.scrollTop) {
@@ -249,10 +249,11 @@ export const NoteList = React.createClass({
         var noteIsBetween = function(note, from, to) {
             var noteTime = new Date(note.timestamp);
 
-            from = from ||
+            from =
+                from ||
                 new Date(noteTime.getFullYear(), noteTime.getMonth(), noteTime.getDate() - 1);
-            to = to ||
-                new Date(noteTime.getFullYear(), noteTime.getMonth(), noteTime.getDate() + 1);
+            to =
+                to || new Date(noteTime.getFullYear(), noteTime.getMonth(), noteTime.getDate() + 1);
 
             if (from < noteTime && noteTime <= to) return true;
             else return false;
@@ -304,18 +305,15 @@ export const NoteList = React.createClass({
         var nextOffset;
 
         /* Build a single list of notes, undo bars, and time group headers */
-        var notes = noteGroups.reduce(
-            function(notes, group, i) {
-                if (0 < group.length) {
-                    header = <ListHeader key={'time-group-' + i} title={_this.groupTitles[i]} />;
-                    notes.push(header);
-                    notes.push.apply(notes, group);
-                }
+        var notes = noteGroups.reduce(function(notes, group, i) {
+            if (0 < group.length) {
+                header = <ListHeader key={'time-group-' + i} title={_this.groupTitles[i]} />;
+                notes.push(header);
+                notes.push.apply(notes, group);
+            }
 
-                return notes;
-            },
-            []
-        );
+            return notes;
+        }, []);
 
         var filter = this.props.filterController.selected;
         var loadingIndicatorVisibility = { opacity: 0 };
@@ -335,7 +333,9 @@ export const NoteList = React.createClass({
                 />
             );
         } else if (
-            !this.props.selectedNoteId && notes.length > 0 && notes.length * 90 > this.props.height
+            !this.props.selectedNoteId &&
+            notes.length > 0 &&
+            notes.length * 90 > this.props.height
         ) {
             // only show if notes exceed window height, estimating note height because
             // we are executing this pre-render
@@ -350,6 +350,7 @@ export const NoteList = React.createClass({
 
         const classes = classNames('wpnc__note-list', {
             'disable-sticky': !!window.chrome && !!window.chrome.webstore, // position: sticky doesn't work in Chrome
+            'is-note-open': !!this.props.selectedNoteId,
         });
 
         return (


### PR DESCRIPTION
Fixes #57 

Adds a missing `box-shadow` to the notes list when no note detail is open.

<img width="53" alt="screen shot 2017-05-03 at 17 29 57" src="https://cloud.githubusercontent.com/assets/2070010/25686835/2cf80b5e-3026-11e7-80cf-2768e4d428f0.png">
