### PR TITLE
Shortcuts: fix panel toggle shortcut

### DIFF
--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -379,7 +379,6 @@ const Layout = React.createClass({
 
         switch (event.keyCode) {
             case KEY_ESC:
-            case KEY_N:
                 this.props.closePanel();
                 stopEvent();
                 break;


### PR DESCRIPTION
This fixes the <kbd>n</kbd> shortcut when the notifications panel is embedded in Calypso without an iframe.

We should follow up in another PR with adding an extra keyhandler for closing the panel when the iframe has focus in `standalone/index` `state/action-middleware/ui` so the iframe behaves correctly in all cases.

cc @Automattic/lannister 

### Testing Instructions
- go to wp-calypso
- checkout `update/integrate-notes-client`
- setup the submodule `git submodule update --init --recursive`
- cd to `client/notifications/notifications-panel`
- checkout this branch
- go back to wp-calypso, `make run`
- pressing <kbd>n</kbd> toggles the notification panel open and closed. You should be able to do this with focus in set in various places on the page.