### PR TITLE
Remove scrollbar from empty lists

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -349,6 +349,10 @@ body {
     	border-left: 1px solid lighten( $gray, 30 );
     	box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
 
+			&.is-empty-list {
+				overflow-y: hidden;
+			}
+
     	@media only screen and (min-width: 409px) and (max-width: 430px) {
     		left: 9px;
     	}

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -98,7 +98,7 @@ export const NoteList = React.createClass({
 
         this.isScrolling = true;
 
-        requestAnimationFrame(() => this.isScrolling = false);
+        requestAnimationFrame(() => (this.isScrolling = false));
 
         const element = ReactDOM.findDOMNode(this.scrollableContainer);
         if (!this.state.scrolling || this.state.scrollY !== element.scrollTop) {
@@ -248,10 +248,11 @@ export const NoteList = React.createClass({
         var noteIsBetween = function(note, from, to) {
             var noteTime = new Date(note.timestamp);
 
-            from = from ||
+            from =
+                from ||
                 new Date(noteTime.getFullYear(), noteTime.getMonth(), noteTime.getDate() - 1);
-            to = to ||
-                new Date(noteTime.getFullYear(), noteTime.getMonth(), noteTime.getDate() + 1);
+            to =
+                to || new Date(noteTime.getFullYear(), noteTime.getMonth(), noteTime.getDate() + 1);
 
             if (from < noteTime && noteTime <= to) return true;
             else return false;
@@ -303,27 +304,26 @@ export const NoteList = React.createClass({
         var nextOffset;
 
         /* Build a single list of notes, undo bars, and time group headers */
-        var notes = noteGroups.reduce(
-            function(notes, group, i) {
-                if (0 < group.length) {
-                    header = <ListHeader key={'time-group-' + i} title={_this.groupTitles[i]} />;
-                    notes.push(header);
-                    notes.push.apply(notes, group);
-                }
+        var notes = noteGroups.reduce(function(notes, group, i) {
+            if (0 < group.length) {
+                header = <ListHeader key={'time-group-' + i} title={_this.groupTitles[i]} />;
+                notes.push(header);
+                notes.push.apply(notes, group);
+            }
 
-                return notes;
-            },
-            []
-        );
+            return notes;
+        }, []);
+
+        const emptyNoteList = 0 === notes.length;
 
         var filter = this.props.filterController.selected;
         var loadingIndicatorVisibility = { opacity: 0 };
         if (this.props.isLoading) {
             loadingIndicatorVisibility.opacity = 1;
-            if (notes.length == 0) {
+            if (emptyNoteList) {
                 loadingIndicatorVisibility.height = this.props.height - TITLE_OFFSET + 'px';
             }
-        } else if (!this.props.initialLoad && notes.length == 0 && filter.emptyMessage) {
+        } else if (!this.props.initialLoad && emptyNoteList && filter.emptyMessage) {
             notes = (
                 <EmptyMessage
                     emptyMessage={filter.emptyMessage}
@@ -334,7 +334,9 @@ export const NoteList = React.createClass({
                 />
             );
         } else if (
-            !this.props.selectedNoteId && notes.length > 0 && notes.length * 90 > this.props.height
+            !this.props.selectedNoteId &&
+            notes.length > 0 &&
+            notes.length * 90 > this.props.height
         ) {
             // only show if notes exceed window height, estimating note height because
             // we are executing this pre-render
@@ -352,17 +354,15 @@ export const NoteList = React.createClass({
             'is-note-open': !!this.props.selectedNoteId,
         });
 
+        const listViewClasses = classNames('wpnc__list-view', {
+            wpnc__current: !!this.props.selectedNoteId,
+            'is-empty-list': emptyNoteList,
+        });
+
         return (
             <div className={classes}>
                 <FilterBar controller={this.props.filterController} />
-                <div
-                    ref={this.storeScrollableContainer}
-                    className={
-                        this.props.selectedNoteId
-                            ? 'wpnc__list-view wpnc__current'
-                            : 'wpnc__list-view'
-                    }
-                >
+                <div ref={this.storeScrollableContainer} className={listViewClasses}>
                     <ol ref={this.storeNoteList} className="wpnc__notes">
                         <StatusBar
                             statusClasses={this.state.statusClasses}


### PR DESCRIPTION
Fixes #65 

Add a new `.is-empty-list` class with `overflow-y: hidden`.

This removes the scrollbars from both the "loading" and "empty" states:

## Screenshots

Notice that the barely visible scrollbar at the right edge of the screens is the browser window one, not the notifications panel one.

| Before | After |
| --- | --- |
| <img width="411" alt="screen shot 2017-05-04 at 10 23 35" src="https://cloud.githubusercontent.com/assets/2070010/25716474/ff9f2460-30b3-11e7-8b4a-92fdea1db0da.png"> | <img width="415" alt="screen shot 2017-05-04 at 10 24 42" src="https://cloud.githubusercontent.com/assets/2070010/25716480/06b2171c-30b4-11e7-9bdf-c398e1d9471c.png"> |
| <img width="413" alt="screen shot 2017-05-04 at 10 23 52" src="https://cloud.githubusercontent.com/assets/2070010/25716473/ff8d7954-30b3-11e7-9c61-7d9011f33415.png"> | <img width="410" alt="screen shot 2017-05-04 at 10 24 28" src="https://cloud.githubusercontent.com/assets/2070010/25716499/151957ac-30b4-11e7-93f3-02e052b5cbda.png"> |
