### PR TITLE
Add missing shadow to the note detail

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -514,6 +514,11 @@ body {
     	height: 100%;
     	left: 0px;
     	right: 0px;
+        box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
+
+        @media only screen and (min-width: 480px) {
+            border-left: 1px solid lighten( $gray, 30 );
+        }
 
     	background-color: $gray-light;
     	ol {
@@ -813,8 +818,6 @@ body {
     		bottom: 0px;
     		z-index: -1;
 
-    		border-left: 1px solid lighten( $gray, 30 );
-
     		header {
     			nav {
     				display: none;
@@ -825,7 +828,6 @@ body {
     			margin-top: 0px;
     		}
 
-    		box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
     		-webkit-transform: translate3d(0, 0, 0); // fix for getting scrollbar in right z-index
     	}
 


### PR DESCRIPTION
Adds the missing shadow to the note detail between 480px ands 800px.

<img width="415" alt="screen shot 2017-05-04 at 12 03 19" src="https://cloud.githubusercontent.com/assets/2070010/25720426/b29d9170-30c1-11e7-94dc-4be53e753129.png">
