### PR TITLE
Preserve list view reset on iframe view

### DIFF
--- a/src/Notifications.jsx
+++ b/src/Notifications.jsx
@@ -28,8 +28,16 @@ repliesCache.cleanup();
  */
 export const refreshNotes = () => client && client.refreshNotes.call(client);
 
+/**
+ * Refresh to default note list view
+ */
+export const reset = () => {
+    store.dispatch(actions.ui.unselectNote());
+};
+
 export class Notifications extends PureComponent {
     static propTypes = {
+        appResetter: PropTypes.func,
         appUpdater: PropTypes.func,
         isShowing: PropTypes.bool,
         isVisible: PropTypes.bool,
@@ -43,6 +51,7 @@ export class Notifications extends PureComponent {
     };
 
     static defaultProps = {
+        appResetter: noop,
         appUpdater: noop,
         isVisible: false,
         locale: 'en',
@@ -55,6 +64,7 @@ export class Notifications extends PureComponent {
 
     componentWillMount() {
         const {
+            appResetter,
             appUpdater,
             isShowing,
             isVisible,
@@ -65,6 +75,7 @@ export class Notifications extends PureComponent {
             wpcom,
         } = this.props;
 
+        appResetter(reset);
         appUpdater(() => this.forceUpdate());
 
         initAPI(wpcom);

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -32,9 +32,13 @@ const onTogglePanel = () => sendMessage({ action: 'togglePanel' });
 let refresh = () => {};
 const appUpdater = f => (refresh = f);
 
+let reset = () => {};
+const appResetter = f => (reset = f);
+
 const render = () => {
     ReactDOM.render(
         React.createElement(AuthWrapper(Notifications), {
+            appResetter,
             appUpdater,
             clientId: 52716,
             isShowing,
@@ -60,6 +64,10 @@ const init = () => {
         'message',
         receiveMessage(({ action, hidden, showing }) => {
             if ('togglePanel' === action) {
+                if (!isShowing && showing) {
+                    reset();
+                }
+
                 isShowing = showing;
                 refresh();
             }


### PR DESCRIPTION
Previously when working inside an iframe, each time the app opened it
would reset to the list view. With the updates we have made it tries to
preserve the previous state: detail view/list view/scroll
position/etc...

This is great for directly embedding as a React component but it was
causing an issue on existing iframe updates. If the app were in detail
view/wide view when closed it would try to return when opened back to
the detail view but lose the widescreen state. This was because of a
state reset on the wide view.

Since we can't go back and update all existing Jetpack deployments we're
trying to preserve this weird behavior. With this patch we will actually
be slightly changing (the scroll positions will be roughly the same as
when closed) but keeping the reset-to-list-view consistent. Calypso will
abandon the existing undesirable behavior but iframes will preserve
them.

cc: @Automattic/lannister @gwwar @apeatling 