### PR TITLE
Stop clearing the selected note when closing panel

### DIFF
--- a/src/state/ui/reducer.js
+++ b/src/state/ui/reducer.js
@@ -1,12 +1,6 @@
 import { combineReducers } from 'redux';
 
-import {
-    CLOSE_PANEL,
-    NOTES_LOADED,
-    NOTES_LOADING,
-    SELECT_NOTE,
-    SET_IS_SHOWING,
-} from '../action-types';
+import { NOTES_LOADED, NOTES_LOADING, SELECT_NOTE, SET_IS_SHOWING } from '../action-types';
 
 export const isLoading = (state = true, { type }) => {
     if (NOTES_LOADING === type) {
@@ -23,17 +17,8 @@ export const isLoading = (state = true, { type }) => {
 export const isPanelOpen = (state = false, { type, isShowing }) =>
     (SET_IS_SHOWING === type ? isShowing : state);
 
-export const selectedNoteId = (state = null, { type, noteId }) => {
-    if (SELECT_NOTE === type) {
-        return noteId;
-    }
-
-    if (CLOSE_PANEL === type) {
-        return null;
-    }
-
-    return state;
-};
+export const selectedNoteId = (state = null, { type, noteId }) =>
+    (SELECT_NOTE === type ? noteId : state);
 
 export default combineReducers({
     isLoading,


### PR DESCRIPTION
Previously whenever we closed the notes panel we would also unselected
the selected note. This meant that we introduced some funny behavior
when closing with the escape key vs with the `n` key or by clicking on
the bell. When closing from the outside the `closePanel()` doesn't get
called and thus the note is not reset. On the other hand, when closing
with the escape key that actions _does_ run.

Now the two behaviors should be unified.

cc: @Automattic/lannister @gwwar @apeatling 