### PR TITLE
Replace noticons in list

### DIFF
--- a/src/indices-to-html/index.js
+++ b/src/indices-to-html/index.js
@@ -1,3 +1,10 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { get } from 'lodash';
+
+import Gridicon from 'templates/gridicons';
+import noticon2gridicon from 'utils/noticon2gridicon';
+
 /**
  * Create the actual DOM nodes for a given piece of text/ranges and
  * recurse downward into the range tree if necessary.
@@ -73,7 +80,13 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
         case 'noticon':
             // Noticons have special text, and are thus not recursed into
             new_container = document.createElement('span');
-            new_container.appendChild(document.createTextNode(range_info.value));
+            new_container.innerHTML =
+              ReactDOMServer.renderToStaticMarkup(
+                React.createElement(
+                  Gridicon,
+                  { icon: noticon2gridicon(range_info.value), size: 18 }
+                )
+              );
             break;
         case 'button':
             new_classes.push('is-primary');

--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -139,13 +139,10 @@ export default React.createClass({
                     </svg>
                 );
 
-            case 'gridicons-stats':
+            case 'gridicons-stats-alt':
                 return (
                     <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                        <title>Stats</title>
-                        <g>
-                            <path d="M19 3H5c-1.105 0-2 .895-2 2v14c0 1.105.895 2 2 2h14c1.105 0 2-.895 2-2V5c0-1.105-.895-2-2-2zm0 16H5V5h14v14zM9 17H7v-5h2v5zm4 0h-2V7h2v10zm4 0h-2v-7h2v7z" />
-                        </g>
+                        <title>Stats Alt</title><g><path d="M21 21H3v-2h18v2zM8 10H4v7h4v-7zm6-7h-4v14h4V3zm6 3h-4v11h4V6z"/></g>
                     </svg>
                 );
 
@@ -198,6 +195,13 @@ export default React.createClass({
                         </g>
                     </svg>
                 );
+
+                    case 'gridicons-reply':
+                        return (
+                            <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <title>Reply</title><g><path d="M14 8H6.828l2.586-2.586L8 4 3 9l5 5 1.414-1.414L6.828 10H14c2.206 0 4 1.794 4 4s-1.794 4-4 4h-2v2h2c3.314 0 6-2.686 6-6s-2.686-6-6-6z"/></g>
+                            </svg>
+                        );
 
             case 'gridicons-arrow-up':
                 return (

--- a/src/templates/summary-in-list.jsx
+++ b/src/templates/summary-in-list.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { flowRight as compose } from 'lodash';
 
+import Gridicon from 'templates/gridicons';
+import noticon2gridicon from 'utils/noticon2gridicon';
+
 import actions from '../state/actions';
 
 import ImagePreloader from './image-loader';
@@ -51,7 +54,10 @@ export const SummaryInList = React.createClass({
                             <img src="https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=128" />
                         }
                     />
-                    <span className="wpnc__noticon">{this.props.note.noticon}</span>
+                  <span className="wpnc__noticon">
+                    <Gridicon icon={noticon2gridicon(this.props.note.noticon)} size={16} />
+                  </span>
+
                 </div>
                 <div className="wpnc__text-summary">
                     <div className="wpnc__subject" dangerouslySetInnerHTML={{ __html: subject }} />

--- a/src/utils/noticon2gridicon.js
+++ b/src/utils/noticon2gridicon.js
@@ -12,6 +12,6 @@ const noticon2gridicon = c => get( {
     '\uf804': 'trophy',
     '\uf467': 'reply',
     '\uf414': 'warning'
-}, c, 'star' );
+}, c, 'info' );
 
 export default noticon2gridicon;

--- a/src/utils/noticon2gridicon.js
+++ b/src/utils/noticon2gridicon.js
@@ -1,0 +1,17 @@
+import { get } from 'lodash';
+
+const noticon2gridicon = c => get( {
+    '\uf814': 'mention',
+    '\uf300': 'comment',
+    '\uf801': 'add',
+    '\uf455': 'info',
+    '\uf470': 'lock',
+    '\uf806': 'stats-alt',
+    '\uf805': 'reblog',
+    '\uf408': 'star',
+    '\uf804': 'trophy',
+    '\uf467': 'reply',
+    '\uf414': 'warning'
+}, c, 'star' );
+
+export default noticon2gridicon;


### PR DESCRIPTION
This replaces the noticons in the list view.

We created a new util that takes the noticons glyph from the shared json and translate it to a string that gridicons can use.

Icons in list to test:

    '\uf814': 'mention',
    '\uf300': 'comment',
    '\uf801': 'add',
    '\uf455': 'info',
    '\uf470': 'lock',
    '\uf806': 'stats-alt',
    '\uf805': 'reblog',
    '\uf408': 'star',
    '\uf804': 'trophy',
    '\uf467': 'reply',
    '\uf414': 'warning'

Reply icon:
<img width="649" alt="screen shot 2017-05-04 at 3 40 13 pm" src="https://cloud.githubusercontent.com/assets/618551/25727907/a1fd4940-30e0-11e7-9582-5e6b64836656.png">

Bubble icons:
<img width="87" alt="screen shot 2017-05-04 at 3 41 44 pm" src="https://cloud.githubusercontent.com/assets/618551/25727916/acfe3b74-30e0-11e7-9d8d-1c4fd388a652.png">
