### PR TITLE
Rename spinner to wpnc__spinner

### DIFF
--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -44,7 +44,7 @@
 			cursor: default;
 		}
 
-		.spinner {
+		.wpnc__spinner {
 			display: block;
 			position: absolute;
 			right: 20px;

--- a/src/boot/stylesheets/spinner.scss
+++ b/src/boot/stylesheets/spinner.scss
@@ -1,5 +1,5 @@
 //CSS Spinner http://codepen.io/MichaelArestad/pen/4f837dd51dc09256115afc9218edda2c
-@keyframes ui-spinner-rotate-right {
+@keyframes ui-wpnc__spinner-rotate-right {
   0% {
     transform: rotate(0deg);
   }
@@ -17,7 +17,7 @@
   }
 }
 
-@keyframes ui-spinner-rotate-left {
+@keyframes ui-wpnc__spinner-rotate-left {
   0% {
     transform: rotate(0deg);
   }
@@ -37,7 +37,7 @@
 
 $size: 20px;
 $transition-speed: .4s;
-.spinner {
+.wpnc__spinner {
 
   position: relative;
     top: 50%;
@@ -126,14 +126,14 @@ $transition-speed: .4s;
     animation-duration: 3s;
   }
   .left:before {
-    animation-name: ui-spinner-rotate-left;
+    animation-name: ui-wpnc__spinner-rotate-left;
   }
   .right:before {
-    animation-name: ui-spinner-rotate-right;
+    animation-name: ui-wpnc__spinner-rotate-right;
   }
 }
 
-.wpnc__loading-indicator .spinner {
+.wpnc__loading-indicator .wpnc__spinner {
   &:before,
   &:after {
     background: $gray-light;

--- a/src/templates/comment-reply-input.jsx
+++ b/src/templates/comment-reply-input.jsx
@@ -284,7 +284,7 @@ const CommentReplyInput = React.createClass({
 
         if (this.state.isSubmitting) {
             submitLink = (
-                <div className="spinner animated">
+                <div className="wpnc__spinner animated">
                     <span className="side left" />
                     <span className="side right" />
                 </div>

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -376,7 +376,7 @@ export const NoteList = React.createClass({
                                 style={loadingIndicatorVisibility}
                                 className="wpnc__loading-indicator"
                             >
-                                <div className="spinner animated">
+                                <div className="wpnc__spinner animated">
                                     <span className="side left" />
                                     <span className="side right" />
                                 </div>


### PR DESCRIPTION
The generic spinner class was creating conflicts when used in Calypso:

![spinner](https://cloud.githubusercontent.com/assets/841763/25742769/4be0127a-3191-11e7-9bd5-c4bc4a1e3115.gif)

Change all instances to more unique `wpnc__spinner`.

Should fix https://github.com/Automattic/wp-calypso/issues/13707 