### PR TITLE
Fix filter bar missing left border

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -181,6 +181,9 @@ body {
     		right: 0px;
     	}
     }
+    .wpnc__note-list:not(.is-note-open) .wpnc__filter {
+    	border-left: 1px solid lighten( $gray, 30 );
+    }
 
     .wpnc__filter__segmented-control {
     	display: table-row; // fallback for browsers not supporting flexbox.


### PR DESCRIPTION
Fixes #68 

Add a left border to the filter bar whenever the note detail is not open.

**not tested yet**

| Before | After (expected) |
| --- | --- |
| <img width="213" alt="screen shot 2017-05-04 at 10 56 01 am" src="https://cloud.githubusercontent.com/assets/1464705/25717856/ba8fe170-30b8-11e7-9c11-8d82e1c8fe13.png"> | <img width="188" alt="screen shot 2017-05-05 at 09 37 16" src="https://cloud.githubusercontent.com/assets/2070010/25755104/7bbf767c-3176-11e7-80df-f16457bd486c.png"> <img width="193" alt="screen shot 2017-05-05 at 09 36 50" src="https://cloud.githubusercontent.com/assets/2070010/25755105/7bbfdebe-3176-11e7-839d-abf46e17b5ba.png"> |