### PR TITLE
Fix transition between list and detail view on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -3,7 +3,7 @@ body {
 }
 
 .wpnc__main {
-		background-color: transparent;
+		background-color: $white;
 
 		font: {
 			family: $sans;
@@ -18,7 +18,7 @@ body {
 			background-color: $gray-light;
 		}
 		@media only screen and (min-width: 409px) and (max-width: 430px) {
-			background-color: transparent;
+			background-color: $white;
 		}
 
     // Text elements


### PR DESCRIPTION
We no longer need the transparent background because the panel is no longer going full width.