### PR TITLE
New notification announcement

### DIFF
--- a/src/rest-client/index.js
+++ b/src/rest-client/index.js
@@ -299,8 +299,6 @@ function getNotesList() {
     });
 }
 
-let hasSeenNotes = false;
-
 /**
  * Reports new notification data if available
  *
@@ -317,7 +315,7 @@ function ready() {
 
     const newNoteCount = timestamps.filter(time => time > this.lastSeenTime).length;
 
-    if (newNoteCount && hasSeenNotes) {
+    if (newNoteCount) {
         this.onRender({
             unseen: newNoteCount,
             latestType: get(notes.slice(-1)[0], 'type', null),
@@ -325,7 +323,6 @@ function ready() {
     }
 
     this.hasNewNoteData = false;
-    hasSeenNotes = true;
 }
 
 /** @type {RegExp} matches keys which may no longer need to exist */


### PR DESCRIPTION
When receiving a new message from pinghub, the bell icon does not update it's status, caused by `hasSeenNotes` initial value of `false`.

Before:
![before](https://cloud.githubusercontent.com/assets/233601/25861740/f437b9be-34bb-11e7-99e9-dfdac945a15f.gif)

After:
![after](https://cloud.githubusercontent.com/assets/233601/25861743/f87065a8-34bb-11e7-9f7f-b5fdea7438a1.gif)

@dmsnell this will rollback https://github.com/Automattic/notifications-panel/pull/90

To test:
run `localStorage.setItem( 'debug', 'notifications:rest-client' );` to enable debug messages and send a new notification.