### PR TITLE
Notes: fix list when notification comes in before panel is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/src/rest-client/index.js
+++ b/src/rest-client/index.js
@@ -154,6 +154,11 @@ function pinghubCallback(err, event) {
 }
 
 function getNote(note_id) {
+    // initialize the list if it's empty
+    if (this.noteList.length === 0) {
+        this.getNotes();
+    }
+
     const parameters = {
         fields: 'id,type,unread,body,subject,timestamp,meta,note_hash',
     };


### PR DESCRIPTION
This fixes https://github.com/Automattic/wp-calypso/issues/13835 where notifications would not fully load if a new notification was received before the panel was opened.

![spinner](https://cloud.githubusercontent.com/assets/1270189/25866894/dd4362a8-34ac-11e7-910f-7c00e898df4e.gif)

### Testing Instructions
Use https://github.com/Automattic/wp-calypso/pull/13843 to test behavior