### PR TITLE
Fixing a one pixel shift when opening a notification in the filter bar.

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -181,12 +181,12 @@ body {
     		right: 0px;
     	}
 
-		@media only screen and (min-width: 800px) {
+		@media only screen and (min-width: 661px) {
 			border-left: 1px solid $white;
 		}
     }
 
-	@media only screen and (min-width: 800px) {
+	@media only screen and (min-width: 661px) {
 	    .wpnc__note-list:not(.is-note-open) .wpnc__filter {
 	    	border-left: 1px solid lighten( $gray, 30 );
 	    }

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -180,10 +180,17 @@ body {
     		width: 400px;
     		right: 0px;
     	}
+
+		@media only screen and (min-width: 800px) {
+			border-left: 1px solid $white;
+		}
     }
-    .wpnc__note-list:not(.is-note-open) .wpnc__filter {
-    	border-left: 1px solid lighten( $gray, 30 );
-    }
+
+	@media only screen and (min-width: 800px) {
+	    .wpnc__note-list:not(.is-note-open) .wpnc__filter {
+	    	border-left: 1px solid lighten( $gray, 30 );
+	    }
+	}
 
     .wpnc__filter__segmented-control {
     	display: table-row; // fallback for browsers not supporting flexbox.


### PR DESCRIPTION
I noticed that the filter bar was shifting over 1 pixel when we removed the border from the left side. This adds a 1px white border when the detail view is showing which fixes the shift.

@Copons can you please review? I also wrapped the border you added previously in a media query so that it doesn't show when the list view is smaller than 800px.

Before:
![before](https://cloud.githubusercontent.com/assets/789137/25876913/0de8ab0c-34d5-11e7-9d93-07c8791bf39c.gif)

After:
![after](https://cloud.githubusercontent.com/assets/789137/25876916/11636e52-34d5-11e7-89c5-657310a6ddf2.gif)
