### PR TITLE
iframe: Fix 10px gap and shift when opening a note

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -174,12 +174,6 @@ body {
     	box-sizing: border-box;
     	direction: ltr;
     	display: table; //fallback for browsers not supporting flexbox
-
-    	@media only screen and (min-width: 409px) and (max-width: 430px) {
-    		left: 10px;
-    		width: 400px;
-    		right: 0px;
-    	}
     }
     .wpnc__note-list:not(.is-note-open) .wpnc__filter {
     	border-left: 1px solid lighten( $gray, 30 );
@@ -333,7 +327,7 @@ body {
     	right: 0;
     	left: auto;
       bottom: 0;
-      width: 410px;
+      width: 400px;
       overflow: hidden;
 			&:not(.is-note-open) {
 				box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -333,7 +333,7 @@ body {
     	right: 0;
     	left: auto;
       bottom: 0;
-      width: 400px;
+      width: 410px;
       overflow: hidden;
 			&:not(.is-note-open) {
 				box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -327,7 +327,7 @@ body {
     	right: 0;
     	left: auto;
       bottom: 0;
-      width: 400px;
+      width: 410px;
       overflow: hidden;
 			&:not(.is-note-open) {
 				box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
@@ -803,7 +803,7 @@ body {
     	}
 
     	.wpnc__single-view {
-    		right: 400px;
+    		right: 410px;
     		left: 10px;
     		top: 0px;
     		bottom: 0px;


### PR DESCRIPTION
We need to adjust the width of the notes list to be 10 pixels wider, because the iframe is set to be 410px wide (I think to make space for scrollbars).

This should fix it for the iframe, but it comes at the cost of making the calypso version 10px wider.

iframe screenshot:
<img width="413" alt="screen shot 2017-05-10 at 5 22 31 pm" src="https://cloud.githubusercontent.com/assets/789137/25926684/60e4a042-35a5-11e7-83c9-1eb8da17dc6d.png">

Fixes #93 