### PR TITLE
Notes: unselect a note when closing the panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/src/Notifications.jsx
+++ b/src/Notifications.jsx
@@ -106,6 +106,8 @@ export class Notifications extends PureComponent {
 
         if (this.props.isShowing && !isShowing) {
             store.dispatch(actions.ui.closePanel());
+            // unselect the note so keyhandlers don't steal keystrokes
+            reset();
         }
 
         if (!this.props.isShowing && isShowing) {


### PR DESCRIPTION
This PR fixes an issue where the notifications panel would steal keystrokes if we closed the panel with a certain type of note selected.

### Testing Instructions

Use https://github.com/Automattic/wp-calypso/pull/14072 to test