### PR TITLE
Close detail view when changing filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/src/templates/filter-bar-controller.js
+++ b/src/templates/filter-bar-controller.js
@@ -1,5 +1,6 @@
 import Filters from './filters';
-
+import { store } from '../state';
+import actions from '../state/actions';
 import { bumpStat } from '../rest-client/bump-stat';
 
 var debug = require('debug')('notifications:filterbarcontroller');
@@ -23,6 +24,8 @@ FilterBarController.prototype.selectFilter = function(filterName) {
     if (this.refreshFunction) {
         this.refreshFunction();
     }
+
+    store.dispatch(actions.ui.unselectNote());
 
     bumpStat('notes-filter-select', filterName);
 };


### PR DESCRIPTION
Dispatch the `unselectNote` action when changing filters, so that the detail view closes in desktop mode.

**To Test**
* In the wide (two-panel) view, select a note. The detail view will open.
* Change to a different filter at the top of the list view (Unread, Comments, etc)
* The detail view should close.
* Also test small screen/mobile interaction works as expected.

Fixes #101