### PR TITLE
Modify text rendering inside notes to add styling

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -655,14 +655,53 @@ body {
           display: block;
         }
       }
+
+      pre {
+        background: $gray-light;
+        border: 1px solid lighten($gray, 20%);
+        border-radius: 3px;
+        padding: 4px;
+
+        code {
+          border: none;
+          background: none;
+        }
+      }
+
+      code {
+        font-family: $code;
+        font-size: 90%;
+        color: darken($gray, 20%);
+        background: $gray-light;
+        border: 1px solid lighten($gray, 20%);
+        border-radius: 3px;
+        padding: 0 2px;
+      }
     }
 
     .wpnc__paragraph:first-of-type {
       margin-top: 0;
     }
 
+    .wpnc__body-list {
+      list-style: disc;
+      padding: 0 16px;
+    }
+
+    .wpnc__body-todo {
+      list-style: none;
+
+      .wpnc__todo-done:before {
+        content: '◉ ';
+      }
+
+      .wpnc__todo-not-done:before {
+        content: '◎ ';
+      }
+    }
+
     blockquote {
-      margin: 0 $padding-medium;
+      margin: 0 $padding-medium $padding-medium;
       font-style: italic;
       color: $gray;
       background: transparent;

--- a/src/templates/functions.jsx
+++ b/src/templates/functions.jsx
@@ -2,16 +2,138 @@ import React from 'react';
 
 import { html as toHtml } from '../indices-to-html';
 
+/**
+ * Adds markup to some common text patterns
+ *
+ *  - Bullet lists
+ *  - Todo lists, WP style
+ *  - Inline `code` snippets
+ *  - Code fences
+ *  - Header: description/explanation paragraphs
+ *
+ * Note: This code is only meant to serve until a
+ * proper parser can be built up to convert the
+ * unstructured text into structured data. Since at
+ * this time we still create HTML strings directly
+ * and on every render this function will serve
+ * sufficiently but it should not be looked upon
+ * as good example code!
+ *
+ * @param {String} text input list of blocks as HTML string
+ * @returns {String} marked-up text
+ */
+const toBlocks = text =>
+  text.split('\n').reduce(({ out, inFence, inList }, raw) => {
+    // detect code fences
+    // ```js
+    // doFoo()
+    // ```
+
+    // code fence?
+    // WordPress can replace `` with a fancy double-quote
+    if (/^(```|“`)[a-z1-9]*\s*$/i.test(raw)) {
+      // opening a fence
+      if (!inFence) {
+        return {
+          out: out + '<pre><code>',
+          inFence: true,
+          inList,
+        };
+      }
+
+      // closing a fence
+      return {
+        out: out + '</code></pre>',
+        inFence: false,
+        inList,
+      };
+    }
+
+    // content inside a fence
+    if (inFence) {
+      return {
+        out: out + raw + '\n',
+        inFence,
+        inList,
+      };
+    }
+
+    // emphasized definition-like text
+    // Some value: some description
+    // Header: Value
+    //
+    // Not! This is fun. This: again; isn't emphasized.
+    // May detect false positive if colon found in first sentence.
+    const defined = /^[\w\s-_]+:/.test(raw)
+      ? `<strong>${raw.split(':')[0]}:</strong>${raw.replace(/^[^:]+:/, '')}`
+      : raw;
+
+    // inline `code` snippets
+    const coded = defined.replace(/`([^`]+)`/, '<code>$1</code>');
+
+    // detect list items
+    //  - one
+    //  * two
+    //  [bullet] three
+    //  [dash] four
+    if (/^\s*[*\-\u2012-\u2015\u2022]\s/.test(coded)) {
+      return {
+        out:
+          out +
+            (inList ? '' : '<ul class="wpnc__body-list">') +
+            `<li>${coded.replace(/^\s*[*\-\u2012-\u2015\u2022]\s/, '')}</li>`,
+        inFence,
+        inList: true,
+      };
+    }
+
+    // detect todo lists
+    //  x Done
+    //  o Not done
+    //  O Also not done
+    // X also done
+
+    if (/^\s*x\s/i.test(coded)) {
+      return {
+        out:
+          out +
+            (inList ? '' : '<ul class="wpnc__body-todo">') +
+            `<li class="wpnc__todo-done">${coded.replace(/^\s*x\s/i, '')}</li>`,
+        inFence,
+        inList: true,
+      };
+    }
+
+    if (/^\s*o\s/i.test(coded)) {
+      return {
+        out:
+          out +
+            (inList ? '' : '<ul class="wpnc__body-todo">') +
+            `<li class="wpnc__todo-not-done">${coded.replace(/^\s*o\s/i, '')}</li>`,
+        inFence,
+        inList: true,
+      };
+    }
+
+    // Return a basic paragraph
+    // anything else…
+    return {
+      out: out + (inList ? '</ul>' : '') + `<div>${coded}</div>`,
+      inFence,
+      inList: false,
+    };
+  }, { out: '', inFence: false, inList: false }).out;
+
 export function internalP(html) {
-  return html.split('\n\n').map(function(chunk) {
-    var somewhatRandomKey =
-      'block-text-' + chunk.length + '-' + Date.now() + '-' + Math.random() * 10000;
+  return html.split('\n\n').map((chunk, i) => {
+    const key = `block-text-${i}-${chunk.length}-${chunk.slice(0, 3)}-${chunk.slice(-3)}`;
+    const blocks = toBlocks(chunk);
 
     return (
       <div
-        key={somewhatRandomKey}
+        key={key}
         dangerouslySetInnerHTML={{
-          __html: chunk.replace(/\n/g, '<br/>'),
+          __html: blocks,
         }}
       />
     );
@@ -22,28 +144,23 @@ export function p(html, className) {
   if (undefined === className) {
     className = 'wpnc__paragraph';
   }
-  return html.split('\n\n').map(function(chunk) {
-    var somewhatRandomKey =
-      'block-text-' + chunk.length + '-' + Date.now() + '-' + Math.random() * 10000;
+  return html.split('\n\n').map((chunk, i) => {
+    const key = `block-text-${i}-${chunk.length}-${chunk.slice(0, 3)}-${chunk.slice(-3)}`;
+    const blocks = toBlocks(chunk);
+
     return (
       <div
         className={className}
-        key={somewhatRandomKey}
+        key={key}
         dangerouslySetInnerHTML={{
-          __html: chunk.replace(/\n/g, '<br/>'),
+          __html: blocks,
         }}
       />
     );
   });
 }
 
-export const pSoup = function(items) {
-  return items
-    .map(function(item) {
-      return toHtml(item);
-    })
-    .map(internalP);
-};
+export const pSoup = items => items.map(toHtml).map(internalP);
 
 export function getSignature(blocks, note) {
   if (!blocks || !blocks.length) {


### PR DESCRIPTION
<del>Resolves automattic/wp-calypso#2044</del> (resolved via API)

<del>A long-standing issue has been the lack of spacing between paragraphs of
text. Every line-break has received a `<br />` tag to separate them but
this left paragraphs flowing without break.</del>

This patch is a hack that adds on some primitive styling in order to get
"the best bang for the buck" until a proper refactor of the text
processing occurs.

Namely:
 - Detect lists and make them real lists with `<ul>` and `<li>`
 - Detect emphasized headers like `Next Week: do something`
 - Split paragraphs of text vertically

The new `toBlocks` reducer does the real work here and takes a fairly
naive approach. Certain bugs exist but I believe that the work in this
patch will relieve much more frustration than it possibly introduces.

@drw158 can you review the use of the bullet? I know there are some styling things I just blasted in without knowing how to do them. also, I seem to remember that we may have intentionally prevented the use of `<li>` so if the bullet isn't right we can change that.

**Testing**
Boot up with `npm start` and do a visual inspection of the notes. Look for inconsistencies in the rendering or blatant problems.