### PR TITLE
Update standalone communication via Redux store injection

### DIFF
--- a/src/Notifications.jsx
+++ b/src/Notifications.jsx
@@ -4,6 +4,7 @@ import { noop } from 'lodash';
 
 import { init as initStore, store } from './state';
 import { init as initPublicAPI } from './state/action-middleware/public-api';
+import { mergeHandlers } from './state/action-middleware/utils';
 import { SET_IS_SHOWING } from './state/action-types';
 import actions from './state/actions';
 
@@ -66,7 +67,8 @@ export class Notifications extends PureComponent {
         const {
             appResetter,
             appUpdater,
-            customMiddleware,
+            customEnhancer,
+            customMiddleware = {},
             isShowing,
             isVisible,
             onLayoutChange,
@@ -76,7 +78,12 @@ export class Notifications extends PureComponent {
             wpcom,
         } = this.props;
 
-        initStore({ customMiddleware });
+        initStore({
+            customEnhancer,
+            customMiddleware: mergeHandlers(customMiddleware, {
+                APP_REFRESH_NOTES: [() => client && client.refreshNotes.call(client)],
+            }),
+        });
 
         appResetter(reset);
         appUpdater(() => this.forceUpdate());
@@ -102,6 +109,7 @@ export class Notifications extends PureComponent {
 
     componentDidMount() {
         this.props.onReady();
+        store.dispatch({ type: 'APP_IS_READY' });
     }
 
     componentWillReceiveProps({ isShowing, isVisible, wpcom }) {

--- a/src/rest-client/index.js
+++ b/src/rest-client/index.js
@@ -325,10 +325,12 @@ function ready() {
         newNoteCount = 0;
     }
 
+    const latestType = get(notes.slice(-1)[0], 'type', null);
     this.onRender({
         unseen: newNoteCount,
-        latestType: get(notes.slice(-1)[0], 'type', null),
+        latestType,
     });
+    store.dispatch({ type: 'APP_RENDER_NOTES', newNoteCount, latestType });
 
     this.hasNewNoteData = false;
     this.firstRender = false;

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -16,7 +16,13 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const withMiddleware = customMiddleware =>
     composeEnhancers(applyMiddleware(actionMiddleware(customMiddleware)))(createStore);
 
-export const init = ({ customMiddleware = {} } = {}) =>
-    (store = withMiddleware(customMiddleware)(reducer, reducer(undefined, { type: '@@INIT' })));
+export const init = ({ customEnhancer, customMiddleware = {} } = {}) => {
+    const middle = withMiddleware(customMiddleware);
+    const create = customEnhancer ? customEnhancer(middle) : middle;
+
+    store = create(reducer, reducer(undefined, { type: '@@INIT' }));
+
+    return store;
+};
 
 export let store = init();

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -13,46 +13,38 @@ const locale = match ? match[1] : 'en';
 let isShowing = true;
 let isVisible = document.visibilityState === 'visible';
 
-const onReady = () => sendMessage({ action: 'iFrameReady' });
+let store = { dispatch: () => {}, getState: () => {} };
+const customEnhancer = next => (reducer, initialState) => (store = next(reducer, initialState));
 
-const onRender = ({ latestType, unseen }) =>
-    (unseen > 0
-        ? sendMessage({
-              action: 'render',
-              num_new: unseen,
-              latest_type: latestType,
-          })
-        : sendMessage({ action: 'renderAllSeen' }));
-
-const onLayoutChange = ({ layout }) =>
-    sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' });
-
-const onTogglePanel = () => sendMessage({ action: 'togglePanel' });
-
-let refresh = () => {};
-const appUpdater = f => (refresh = f);
-
-let reset = () => {};
-const appResetter = f => (reset = f);
+const refresh = () => store && store.dispatch({ type: 'APP_REFRESH_NOTES' });
+const reset = () => store && store.dispatch({ type: 'SELECT_NOTE', noteId: null });
 
 const customMiddleware = {
+    APP_IS_READY: [() => sendMessage({ action: 'iFrameReady' })],
+    APP_RENDER_NOTES: [
+        (store, { latestType, newNoteCount }) =>
+            (newNoteCount > 0
+                ? sendMessage({ action: 'render', num_new: newNoteCount, latest_type: latestType })
+                : sendMessage({ action: 'renderAllSeen' })),
+    ],
+    CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
+    OPEN_PANEL: [() => sendMessage({ action: 'togglePanel' })],
+    SET_LAYOUT: [
+        (store, { layout }) =>
+            sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),
+    ],
     VIEW_SETTINGS: [() => window.open('https://wordpress.com/me/notifications')],
 };
 
 const render = () => {
     ReactDOM.render(
         React.createElement(AuthWrapper(Notifications), {
-            appResetter,
-            appUpdater,
             clientId: 52716,
+            customEnhancer,
             customMiddleware,
             isShowing,
             isVisible,
             locale,
-            onLayoutChange,
-            onReady,
-            onRender,
-            onTogglePanel,
             receiveMessage: sendMessage,
             redirectPath: '/',
         }),


### PR DESCRIPTION
 - Creates a `customEnhancer` which can inject actions into the app
 - Moves standalone prop function passers into store enhancement

**Testing**

Needs to be tested when deployed in a sandbox, but this shouldn't change any behavior (certainly not in Calypso)