### PR TITLE
Fix regression that removed placeholder text and 'The End' message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -286,7 +286,7 @@ export const NoteList = React.createClass({
             return findIndex(timeGroups, ([after, before]) => before < time && time <= after);
         });
 
-        let notes = reduce(
+        let [ notes ] = reduce(
             noteGroups,
             ([list, isFirst], group, index) => {
                 const title = groupTitles[index];

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -286,7 +286,7 @@ export const NoteList = React.createClass({
             return findIndex(timeGroups, ([after, before]) => before < time && time <= after);
         });
 
-        let [ notes ] = reduce(
+        let [notes] = reduce(
             noteGroups,
             ([list, isFirst], group, index) => {
                 const title = groupTitles[index];


### PR DESCRIPTION
**To Test**
* Visit the Unread tab and read all of your notifications, a placeholder should appear: "All caught up!"
* Go to the All tab and scroll alllll the way down to the bottom. You should see "The End"