### PR TITLE
Open posts via Redux action

### DIFF
--- a/src/indices-to-html/index.js
+++ b/src/indices-to-html/index.js
@@ -94,6 +94,7 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
             if (options.links && range_info.url) {
                 // We are a link of some sort...
                 new_container = document.createElement('a');
+
                 new_container.setAttribute('href', range_info.url);
                 if (range_info_type == 'stat') {
                     // Stat links should change the whole window/tab
@@ -101,6 +102,15 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
                 } else {
                     // Other links should link into a new window/tab
                     new_container.setAttribute('target', '_blank');
+                }
+
+                if ('post' === range_info.type) {
+                    new_container.setAttribute('href', '#');
+                    new_container.setAttribute('data-post-id', range_info.id);
+                    new_container.setAttribute('data-site-id', range_info.site_id);
+                    new_container.setAttribute('data-href', range_info.url);
+                    new_container.setAttribute('data-link-type', 'post');
+                    new_container.setAttribute('target', '_self');
                 }
 
                 build_chunks(new_sub_text, new_sub_range, range_data, new_container, options);

--- a/src/indices-to-html/index.js
+++ b/src/indices-to-html/index.js
@@ -105,10 +105,8 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
                 }
 
                 if ('post' === range_info.type) {
-                    new_container.setAttribute('href', '#');
                     new_container.setAttribute('data-post-id', range_info.id);
                     new_container.setAttribute('data-site-id', range_info.site_id);
-                    new_container.setAttribute('data-href', range_info.url);
                     new_container.setAttribute('data-link-type', 'post');
                     new_container.setAttribute('target', '_self');
                 }

--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -14,6 +14,7 @@ import NoteList from './note-list';
 import AppError from './error';
 import FilterBarController from './filter-bar-controller';
 import Note from './note';
+import { interceptLinks } from '../utils/link-interceptor';
 
 import actions from '../state/actions';
 import getAllNotes from '../state/selectors/get-all-notes';
@@ -478,7 +479,7 @@ const Layout = React.createClass({
         const filteredNotes = this.filterController.getFilteredNotes(this.props.notes);
 
         return (
-            <div>
+            <div onClick={interceptLinks}>
                 {this.props.error && <AppError error={this.props.error} />}
 
                 {!this.props.error &&

--- a/src/templates/summary-in-single.jsx
+++ b/src/templates/summary-in-single.jsx
@@ -2,17 +2,37 @@ import React from 'react';
 
 import { html } from '../indices-to-html';
 
-var Snippet = React.createClass({
-    render: function() {
-        return (
-            <a href={this.props.url} target="_blank">
-                <span className="wpnc__excerpt">
-                    {this.props.snippet.text}
-                </span>
-            </a>
-        );
-    },
-});
+const snippetProps = snippet => {
+    if (!snippet) {
+        return {};
+    }
+
+    const { ranges = [] } = snippet;
+    if (!ranges.length) {
+        return {};
+    }
+
+    const { id, site_id, type } = ranges[0];
+
+    switch (type) {
+        case 'post':
+            return {
+                'data-link-type': type,
+                'data-site-id': site_id,
+                'data-post-id': id,
+            };
+        default:
+            return {};
+    }
+};
+
+const Snippet = ({ url, snippet }) => (
+    <a href={url} {...snippetProps(snippet)} target="_blank">
+        <span className="wpnc__excerpt">
+            {snippet.text}
+        </span>
+    </a>
+);
 
 var UserHeader = React.createClass({
     render: function() {

--- a/src/templates/summary-in-single.jsx
+++ b/src/templates/summary-in-single.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { html } from '../indices-to-html';
 
@@ -16,18 +15,6 @@ var Snippet = React.createClass({
 });
 
 var UserHeader = React.createClass({
-    interceptLinks(event) {
-        const { target } = event;
-        const { dataset = {} } = target;
-        const { href, linkType, postId, siteId } = dataset;
-
-        if ('post' === linkType) {
-            return this.props.openPost(siteId, postId, href);
-        }
-
-        return this.props.openLink(href);
-    },
-
     render: function() {
         var grav = this.props.user.media[0];
         var grav_tag = <img src={grav.url} height={grav.height} width={grav.width} />;
@@ -61,7 +48,6 @@ var UserHeader = React.createClass({
                         dangerouslySetInnerHTML={{
                             __html: html(usercopy),
                         }}
-                        onClick={this.interceptLinks}
                     />
                     <Snippet snippet={this.props.snippet} url={this.props.url} />
 
@@ -128,7 +114,6 @@ const SummaryInSingle = React.createClass({
                         user={this.props.note.header[0]}
                         snippet={this.props.note.header[1]}
                         url={header_url}
-                        openPost={this.props.openPost}
                     />
                 );
             }
@@ -151,9 +136,4 @@ const SummaryInSingle = React.createClass({
     },
 });
 
-const mapDispatchToProps = dispatch => ({
-    openLink: href => dispatch({ type: 'OPEN_LINK', href }),
-    openPost: (siteId, postId, href) => dispatch({ type: 'OPEN_POST', siteId, postId, href }),
-});
-
-export default connect(null, mapDispatchToProps)(SummaryInSingle);
+export default SummaryInSingle;

--- a/src/templates/summary-in-single.jsx
+++ b/src/templates/summary-in-single.jsx
@@ -2,14 +2,38 @@ import React from 'react';
 
 import { html } from '../indices-to-html';
 
-const snippetProps = snippet => {
-    if (!snippet) {
+const subjectProps = noteSubject => {
+    if (!noteSubject || !noteSubject[0]) {
         return {};
+    }
+
+    const { ranges } = noteSubject[0];
+    if (!ranges.length) {
+        return {};
+    }
+
+    const posts = ranges.filter(({ type }) => 'post' === type);
+    if (posts.length !== 1) {
+        return {};
+    }
+
+    const post = posts[0];
+
+    return {
+        'data-link-type': post.type,
+        'data-site-id': post.site_id,
+        'data-post-id': post.id,
+    };
+};
+
+const snippetProps = (snippet, noteSubject) => {
+    if (!snippet) {
+        return subjectProps(noteSubject);
     }
 
     const { ranges = [] } = snippet;
     if (!ranges.length) {
-        return {};
+        return subjectProps(noteSubject);
     }
 
     const { id, site_id, type } = ranges[0];
@@ -22,12 +46,12 @@ const snippetProps = snippet => {
                 'data-post-id': id,
             };
         default:
-            return {};
+            return subjectProps(noteSubject);
     }
 };
 
-const Snippet = ({ url, snippet }) => (
-    <a href={url} {...snippetProps(snippet)} target="_blank">
+const Snippet = ({ url, snippet, noteSubject }) => (
+    <a href={url} {...snippetProps(snippet, noteSubject)} target="_blank">
         <span className="wpnc__excerpt">
             {snippet.text}
         </span>
@@ -69,7 +93,11 @@ var UserHeader = React.createClass({
                             __html: html(usercopy),
                         }}
                     />
-                    <Snippet snippet={this.props.snippet} url={this.props.url} />
+                    <Snippet
+                        noteSubject={this.props.noteSubject}
+                        snippet={this.props.snippet}
+                        url={this.props.url}
+                    />
 
                 </div>
             );
@@ -82,7 +110,11 @@ var UserHeader = React.createClass({
                             {get_home_link('wpnc__user__home', this.props.user.text)}
                         </span>
                     </div>
-                    <Snippet snippet={this.props.snippet} url={this.props.url} />
+                    <Snippet
+                        noteSubject={this.props.noteSubject}
+                        snippet={this.props.snippet}
+                        url={this.props.url}
+                    />
                 </div>
             );
         }
@@ -104,7 +136,11 @@ var Header = React.createFactory(
             return (
                 <div className="wpnc__summary">
                     {subject}
-                    <Snippet snippet={this.props.snippet} url={this.props.url} />
+                    <Snippet
+                        noteSubject={this.props.noteSubject}
+                        snippet={this.props.snippet}
+                        url={this.props.url}
+                    />
                 </div>
             );
         },
@@ -131,24 +167,27 @@ const SummaryInSingle = React.createClass({
                 }
                 return (
                     <UserHeader
-                        user={this.props.note.header[0]}
+                        noteSubject={this.props.note.subject}
                         snippet={this.props.note.header[1]}
                         url={header_url}
+                        user={this.props.note.header[0]}
                     />
                 );
             }
             return (
                 <Header
-                    subject={this.props.note.header[0]}
+                    noteSubject={this.props.note.subject}
                     snippet={this.props.note.header[1]}
+                    subject={this.props.note.header[0]}
                     url={this.props.note.url}
                 />
             );
         } else {
             return (
                 <Header
-                    subject={this.props.note.header[0]}
+                    noteSubject={this.props.note.subject}
                     snippet={''}
+                    subject={this.props.note.header[0]}
                     url={this.props.note.url}
                 />
             );

--- a/src/templates/summary-in-single.jsx
+++ b/src/templates/summary-in-single.jsx
@@ -2,41 +2,33 @@ import React from 'react';
 
 import { html } from '../indices-to-html';
 
-const subjectProps = noteSubject => {
-    if (!noteSubject || !noteSubject[0]) {
-        return {};
+const getPostRef = note => {
+    const { header = [] } = note;
+    const hRanges = header.map(({ ranges = [] }) => ranges).reduce((a, b) => [...a, ...b], []);
+    const hPosts = hRanges.filter(({ type }) => 'post' === type);
+
+    if (hPosts.length === 1) {
+        return hPosts[0];
     }
 
-    const { ranges } = noteSubject[0];
-    if (!ranges.length) {
-        return {};
+    const { subject = [] } = note;
+    const sRanges = subject.map(({ ranges = [] }) => ranges).reduce((a, b) => [...a, ...b], []);
+    const sPosts = sRanges.filter(({ type }) => 'post' === type);
+
+    if (sPosts.length === 1) {
+        return sPosts[0];
     }
 
-    const posts = ranges.filter(({ type }) => 'post' === type);
-    if (posts.length !== 1) {
-        return {};
-    }
-
-    const post = posts[0];
-
-    return {
-        'data-link-type': post.type,
-        'data-site-id': post.site_id,
-        'data-post-id': post.id,
-    };
+    return null;
 };
 
-const snippetProps = (snippet, noteSubject) => {
-    if (!snippet) {
-        return subjectProps(noteSubject);
+const linkProps = note => {
+    const post = getPostRef(note);
+    if (!post) {
+        return {};
     }
 
-    const { ranges = [] } = snippet;
-    if (!ranges.length) {
-        return subjectProps(noteSubject);
-    }
-
-    const { id, site_id, type } = ranges[0];
+    const { id, site_id, type } = post;
 
     switch (type) {
         case 'post':
@@ -46,12 +38,12 @@ const snippetProps = (snippet, noteSubject) => {
                 'data-post-id': id,
             };
         default:
-            return subjectProps(noteSubject);
+            return {};
     }
 };
 
-const Snippet = ({ url, snippet, noteSubject }) => (
-    <a href={url} {...snippetProps(snippet, noteSubject)} target="_blank">
+const Snippet = ({ note, snippet, url }) => (
+    <a href={url} {...linkProps(note)} target="_blank">
         <span className="wpnc__excerpt">
             {snippet.text}
         </span>
@@ -94,7 +86,7 @@ var UserHeader = React.createClass({
                         }}
                     />
                     <Snippet
-                        noteSubject={this.props.noteSubject}
+                        note={this.props.note}
                         snippet={this.props.snippet}
                         url={this.props.url}
                     />
@@ -111,7 +103,7 @@ var UserHeader = React.createClass({
                         </span>
                     </div>
                     <Snippet
-                        noteSubject={this.props.noteSubject}
+                        note={this.props.note}
                         snippet={this.props.snippet}
                         url={this.props.url}
                     />
@@ -137,7 +129,7 @@ var Header = React.createFactory(
                 <div className="wpnc__summary">
                     {subject}
                     <Snippet
-                        noteSubject={this.props.noteSubject}
+                        note={this.props.note}
                         snippet={this.props.snippet}
                         url={this.props.url}
                     />
@@ -167,7 +159,7 @@ const SummaryInSingle = React.createClass({
                 }
                 return (
                     <UserHeader
-                        noteSubject={this.props.note.subject}
+                        note={this.props.note}
                         snippet={this.props.note.header[1]}
                         url={header_url}
                         user={this.props.note.header[0]}
@@ -176,7 +168,7 @@ const SummaryInSingle = React.createClass({
             }
             return (
                 <Header
-                    noteSubject={this.props.note.subject}
+                    note={this.props.note}
                     snippet={this.props.note.header[1]}
                     subject={this.props.note.header[0]}
                     url={this.props.note.url}
@@ -185,7 +177,7 @@ const SummaryInSingle = React.createClass({
         } else {
             return (
                 <Header
-                    noteSubject={this.props.note.subject}
+                    note={this.props.note}
                     snippet={''}
                     subject={this.props.note.header[0]}
                     url={this.props.note.url}

--- a/src/templates/summary-in-single.jsx
+++ b/src/templates/summary-in-single.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { html } from '../indices-to-html';
 
@@ -15,6 +16,18 @@ var Snippet = React.createClass({
 });
 
 var UserHeader = React.createClass({
+    interceptLinks(event) {
+        const { target } = event;
+        const { dataset = {} } = target;
+        const { href, linkType, postId, siteId } = dataset;
+
+        if ('post' === linkType) {
+            return this.props.openPost(siteId, postId, href);
+        }
+
+        return this.props.openLink(href);
+    },
+
     render: function() {
         var grav = this.props.user.media[0];
         var grav_tag = <img src={grav.url} height={grav.height} width={grav.width} />;
@@ -48,6 +61,7 @@ var UserHeader = React.createClass({
                         dangerouslySetInnerHTML={{
                             __html: html(usercopy),
                         }}
+                        onClick={this.interceptLinks}
                     />
                     <Snippet snippet={this.props.snippet} url={this.props.url} />
 
@@ -114,6 +128,7 @@ const SummaryInSingle = React.createClass({
                         user={this.props.note.header[0]}
                         snippet={this.props.note.header[1]}
                         url={header_url}
+                        openPost={this.props.openPost}
                     />
                 );
             }
@@ -136,4 +151,9 @@ const SummaryInSingle = React.createClass({
     },
 });
 
-export default SummaryInSingle;
+const mapDispatchToProps = dispatch => ({
+    openLink: href => dispatch({ type: 'OPEN_LINK', href }),
+    openPost: (siteId, postId, href) => dispatch({ type: 'OPEN_POST', siteId, postId, href }),
+});
+
+export default connect(null, mapDispatchToProps)(SummaryInSingle);

--- a/src/utils/link-interceptor.js
+++ b/src/utils/link-interceptor.js
@@ -1,0 +1,32 @@
+import { store } from '../state';
+
+const openLink = href => ({ type: 'OPEN_LINK', href });
+const openPost = (siteId, postId, href) => ({ type: 'OPEN_POST', siteId, postId, href });
+
+export const interceptLinks = event => {
+    const { target } = event;
+
+    if ('A' !== target.tagName) {
+        return true;
+    }
+
+    const { dataset = {}, href } = target;
+    const { linkType, postId, siteId } = dataset;
+
+    if (!linkType) {
+        return true;
+    }
+
+    event.stopPropagation();
+    event.preventDefault();
+
+    if ('post' === linkType) {
+        store.dispatch(openPost(siteId, postId, href));
+    } else {
+        store.dispatch(openLink(href));
+    }
+
+    return false;
+};
+
+export default interceptLinks;

--- a/src/utils/link-interceptor.js
+++ b/src/utils/link-interceptor.js
@@ -6,11 +6,12 @@ const openPost = (siteId, postId, href) => ({ type: 'OPEN_POST', siteId, postId,
 export const interceptLinks = event => {
     const { target } = event;
 
-    if ('A' !== target.tagName) {
+    if ('A' !== target.tagName && 'A' !== target.parentNode.tagName) {
         return true;
     }
 
-    const { dataset = {}, href } = target;
+    const node = 'A' === target.tagName ? target : target.parentNode;
+    const { dataset = {}, href } = node;
     const { linkType, postId, siteId } = dataset;
 
     if (!linkType) {

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -28,12 +28,9 @@ const customMiddleware = {
                 : sendMessage({ action: 'renderAllSeen' })),
     ],
     CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
-    OPEN_LINK: [(store, { href }) => window.open(href, '_blank', 'nofollow,noreferrer,noopener')],
+    OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
     OPEN_PANEL: [() => sendMessage({ action: 'togglePanel' })],
-    OPEN_POST: [
-        (store, { siteId, postId, href }) =>
-            window.open(href, '_blank', 'nofollow,noreferrer,noopener'),
-    ],
+    OPEN_POST: [(store, { siteId, postId, href }) => window.open(href, '_blank')],
     SET_LAYOUT: [
         (store, { layout }) =>
             sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -28,7 +28,11 @@ const customMiddleware = {
                 : sendMessage({ action: 'renderAllSeen' })),
     ],
     CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
+    OPEN_LINK: [(store, { href }) => window.open(href, '_blank', 'nofollow,noreferrer,noopener')],
     OPEN_PANEL: [() => sendMessage({ action: 'togglePanel' })],
+    OPEN_POST: [
+        (store, { siteId, postId, href }) =>
+            window.open(href, '_blank', 'nofollow,noreferrer,noopener'),
     SET_LAYOUT: [
         (store, { layout }) =>
             sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -33,6 +33,7 @@ const customMiddleware = {
     OPEN_POST: [
         (store, { siteId, postId, href }) =>
             window.open(href, '_blank', 'nofollow,noreferrer,noopener'),
+    ],
     SET_LAYOUT: [
         (store, { layout }) =>
             sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),


### PR DESCRIPTION
Detects post links in notification headers and fires a Redux action to open it instead of directly opening a new browser window.

**Testing**

The only real change is to the `<Snippet />` so to test click on the link in the excerpt area.

Test with `npm start` locally to make sure this doesn't change the existing behavior. Links should open new browser sessions. Test with as many notes as possible.

Test also in Calypso with Automattic/calypso#14396 or in its [live branch](https://calypso.live/?branch=update/integrate-notes-client-post-links). Post links should now navigate Calypso to the appropriate post in the reader view.