### PR TITLE
Use Flexbox for vertical centering.

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -323,9 +323,11 @@ body {
     }
 
     .wpnc__loading-indicator {
-    	display: block;
-    	background-color: $gray-light;
-    	height: 90px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background-color: $gray-light;
+		height: 100%;
     }
 
     .wpnc__note-list {

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -309,8 +309,9 @@ body {
     }
 
     .wpnc__empty-notes {
-    	text-align: center;
-    	padding: 0 32px;
+		text-align: center;
+		padding: 0 32px;
+		transform: translateY(-50%);
 
     	h2 {
     		font: 300 21px/24px $sans;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -246,7 +246,8 @@ body {
     }
 
     .wpnc__list-view .wpnc__notes, .error {
-    	background-color: $white;
+		background-color: $white;
+		height: 100%;
     }
 
     .wpnc__note {
@@ -300,15 +301,16 @@ body {
     }
 
     .wpnc__empty-notes-container {
-    	background-color: $gray-light;
+		background-color: $gray-light;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
     }
 
     .wpnc__empty-notes {
     	text-align: center;
-    	position: relative;
-    		top: 50%;
     	padding: 0 32px;
-    	transform: translateY(-50%);
 
     	h2 {
     		font: 300 21px/24px $sans;

--- a/src/boot/stylesheets/spinner.scss
+++ b/src/boot/stylesheets/spinner.scss
@@ -38,10 +38,7 @@
 $size: 20px;
 $transition-speed: .4s;
 .wpnc__spinner {
-
   position: relative;
-    top: 50%;
-    left: 50%;
   transform: translate(-50%, -50%);
   border-radius: 100%;
   width: $size;

--- a/src/templates/empty-message.jsx
+++ b/src/templates/empty-message.jsx
@@ -2,9 +2,6 @@ import React from 'react';
 
 import { bumpStat } from '../rest-client/bump-stat';
 
-// from $title-offset in boot/sizes.scss
-var TITLE_OFFSET = 38;
-
 export const EmptyMessage = React.createClass({
     componentWillMount: function() {
         if (this.props.showing) {
@@ -51,10 +48,7 @@ export const EmptyMessage = React.createClass({
         }
 
         return (
-            <div
-                className="wpnc__empty-notes-container"
-                style={{ height: window.innerHeight - TITLE_OFFSET + 'px' }}
-            >
+			<div className="wpnc__empty-notes-container">
                 {message}
             </div>
         );

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -303,9 +303,6 @@ export const NoteList = React.createClass({
         var loadingIndicatorVisibility = { opacity: 0 };
         if (this.props.isLoading) {
             loadingIndicatorVisibility.opacity = 1;
-            if (emptyNoteList) {
-                loadingIndicatorVisibility.height = this.props.height - TITLE_OFFSET + 'px';
-            }
         } else if (!this.props.initialLoad && emptyNoteList && filter.emptyMessage) {
             notes = (
                 <EmptyMessage


### PR DESCRIPTION
Rather than using [JavaScript](https://github.com/Automattic/notifications-panel/blob/7c1815301b2af437a4fd6e918c96747cd99c0f0a/src/templates/empty-message.jsx#L56) and [math](https://github.com/Automattic/notifications-panel/blob/master/src/boot/stylesheets/main.scss#L306) to vertically center elements, this PR uses Flexbox.

![screen shot 2017-05-29 at 2 55 26 pm](https://cloud.githubusercontent.com/assets/349751/26562838/052ae854-447f-11e7-8a5c-a39c5e5338f8.png)
_Current / With fix / With fix + transform -50%. Note the environment badges were removed for clarity._

Using Flexbox still looks a little visually low (can't tell why), but adding back the transform that I originally pulled out seems to look better. SInce it's a `div` being vertically centered, I shouldn't _have_ to do that; but it does seem to be vertically aligned to the first line of text. @drw158 am I missing something? (Hm, maybe even `-25%` would be better.)

**Testing**
* Switch to this PR locally.
* Run the repo as standalone to be sure of no regressions.
* In both `packages.json` and `npm-shrinkwrap.json`, change the `"notifications-panel"` value to `"Automattic/notifications-panel#fix\/vertical-centering"`.
* `make distclean` and `make run`. Come back tomorrow.
* Check the notifications > Unread tab for spinner and message positioning.

Fixes #113.