### PR TITLE
Add filter name to redux store

### DIFF
--- a/src/state/action-types.js
+++ b/src/state/action-types.js
@@ -17,3 +17,4 @@ export const SUGGESTIONS_STORE = 'SUGGESTIONS_STORE';
 export const TRASH_NOTE = 'TRASH_NOTE';
 export const UNDO_ACTION = 'UNDO_ACTION';
 export const VIEW_SETTINGS = 'VIEW_SETTINGS';
+export const SET_FILTER = 'SET_FILTER';

--- a/src/state/selectors/get-filter-name.js
+++ b/src/state/selectors/get-filter-name.js
@@ -1,0 +1,5 @@
+import getUI from './get-ui';
+
+const getFilterName = uiState => uiState.filterName;
+
+export default state => getFilterName(getUI(state));

--- a/src/state/ui/actions.js
+++ b/src/state/ui/actions.js
@@ -7,6 +7,7 @@ import {
     SET_LAYOUT,
     UNDO_ACTION,
     VIEW_SETTINGS,
+    SET_FILTER,
 } from '../action-types';
 
 export const closePanel = () => ({
@@ -46,6 +47,11 @@ export const viewSettings = () => ({
     type: VIEW_SETTINGS,
 });
 
+export const setFilter = filterName => ({
+    type: SET_FILTER,
+    filterName,
+});
+
 export default {
     closePanel,
     loadNotes,
@@ -56,4 +62,5 @@ export default {
     undoAction,
     unselectNote,
     viewSettings,
+    setFilter,
 };

--- a/src/state/ui/reducer.js
+++ b/src/state/ui/reducer.js
@@ -35,9 +35,8 @@ export const selectedNoteId = (state = null, { type, noteId }) => {
     return state;
 };
 
-export const filterName = (state = 'all', { type, filterName }) => {
-    return SET_FILTER === type ? filterName : state;
-};
+export const filterName = (state = 'all', { type, filterName }) =>
+    ( SET_FILTER === type ? filterName : state );
 
 export default combineReducers({
     isLoading,

--- a/src/state/ui/reducer.js
+++ b/src/state/ui/reducer.js
@@ -1,6 +1,12 @@
 import { combineReducers } from 'redux';
 
-import { NOTES_LOADED, NOTES_LOADING, SELECT_NOTE, SET_IS_SHOWING } from '../action-types';
+import {
+    NOTES_LOADED,
+    NOTES_LOADING,
+    SELECT_NOTE,
+    SET_IS_SHOWING,
+    SET_FILTER
+} from '../action-types';
 
 export const isLoading = (state = true, { type }) => {
     if (NOTES_LOADING === type) {
@@ -20,8 +26,13 @@ export const isPanelOpen = (state = false, { type, isShowing }) =>
 export const selectedNoteId = (state = null, { type, noteId }) =>
     (SELECT_NOTE === type ? noteId : state);
 
+export const filterName = (state = 'all', { type, filterName }) => {
+    return SET_FILTER === type ? filterName : state;
+};
+
 export default combineReducers({
     isLoading,
     isPanelOpen,
     selectedNoteId,
+    filterName,
 });

--- a/src/templates/filter-bar-controller.js
+++ b/src/templates/filter-bar-controller.js
@@ -1,6 +1,7 @@
 import Filters from './filters';
 import { store } from '../state';
 import actions from '../state/actions';
+import getFilterName from '../state/selectors/get-filter-name';
 import { bumpStat } from '../rest-client/bump-stat';
 
 var debug = require('debug')('notifications:filterbarcontroller');
@@ -30,7 +31,7 @@ FilterBarController.prototype.selectFilter = function(filterName) {
 };
 
 FilterBarController.prototype.getFilteredNotes = function(notes) {
-    const activeTab = Filters[store.getState().ui.filterName];
+    const activeTab = Filters[getFilterName(store.getState())];
     if (!notes || !activeTab) {
         return [];
     }

--- a/src/templates/filter-bar-controller.js
+++ b/src/templates/filter-bar-controller.js
@@ -10,7 +10,6 @@ function FilterBarController(refreshFunction) {
         return new FilterBarController(refreshFunction);
     }
 
-    this.selected = Filters.all();
     this.refreshFunction = refreshFunction;
 }
 
@@ -19,7 +18,7 @@ FilterBarController.prototype.selectFilter = function(filterName) {
         return;
     }
 
-    this.selected = Filters[filterName]();
+    store.dispatch(actions.ui.setFilter(filterName));
 
     if (this.refreshFunction) {
         this.refreshFunction();
@@ -31,12 +30,12 @@ FilterBarController.prototype.selectFilter = function(filterName) {
 };
 
 FilterBarController.prototype.getFilteredNotes = function(notes) {
-    if (!notes) {
+    const activeTab = Filters[store.getState().ui.filterName];
+    if (!notes || !activeTab) {
         return [];
     }
 
-    const filterFunction = (this.selected && this.selected.filter) || (a => a);
-    return notes.filter(filterFunction);
+    return notes.filter(activeTab().filter);
 };
 
 export default FilterBarController;

--- a/src/templates/filter-bar.jsx
+++ b/src/templates/filter-bar.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import Filters from './filters';
+import getFilterName from '../state/selectors/get-filter-name';
 
 var debug = require('debug')('notifications:filterbar');
 var classnames = require('classnames');
@@ -36,7 +38,7 @@ export const FilterBar = React.createClass({
 
         filterItems = filterItems.map(function(filter) {
             const classes = classnames('wpnc__filter__segmented-control-item', {
-                selected: filter.name === this.props.controller.selected.name,
+                selected: filter.name === this.props.filterName,
             });
 
             return (
@@ -61,4 +63,8 @@ export const FilterBar = React.createClass({
     },
 });
 
-export default FilterBar;
+const mapStateToProps = state => ({
+    filterName: getFilterName(state),
+});
+
+export default connect(mapStateToProps, null, null, { pure: false })(FilterBar);

--- a/src/templates/filter-bar.jsx
+++ b/src/templates/filter-bar.jsx
@@ -67,4 +67,4 @@ const mapStateToProps = state => ({
     filterName: getFilterName(state),
 });
 
-export default connect(mapStateToProps, null)(FilterBar);
+export default connect(mapStateToProps)(FilterBar);

--- a/src/templates/filter-bar.jsx
+++ b/src/templates/filter-bar.jsx
@@ -67,4 +67,4 @@ const mapStateToProps = state => ({
     filterName: getFilterName(state),
 });
 
-export default connect(mapStateToProps, null, null, { pure: false })(FilterBar);
+export default connect(mapStateToProps, null)(FilterBar);

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import { findIndex, groupBy, reduce, zip } from 'lodash';
 
 import actions from '../state/actions';
+import getFilterName from '../state/selectors/get-filter-name';
 import getIsLoading from '../state/selectors/get-is-loading';
 import getIsNoteHidden from '../state/selectors/get-is-note-hidden';
 import getIsPanelOpen from '../state/selectors/get-is-panel-open';
@@ -13,6 +14,7 @@ import getSelectedNoteId from '../state/selectors/get-selected-note-id';
 
 import EmptyMessage from './empty-message';
 import FilterBar from './filter-bar';
+import Filters from './filters';
 import ListHeader from './list-header';
 import Note from './note';
 import StatusBar from './status-bar';
@@ -299,7 +301,7 @@ export const NoteList = React.createClass({
 
         const emptyNoteList = 0 === notes.length;
 
-        var filter = this.props.filterController.selected;
+        var filter = Filters[this.props.filterName];
         var loadingIndicatorVisibility = { opacity: 0 };
         if (this.props.isLoading) {
             loadingIndicatorVisibility.opacity = 1;
@@ -376,6 +378,7 @@ const mapStateToProps = state => ({
     isNoteHidden: noteId => getIsNoteHidden(state, noteId),
     isPanelOpen: getIsPanelOpen(state),
     selectedNoteId: getSelectedNoteId(state),
+    filterName: getFilterName(state),
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
In order to add a solution for #103 we need to add the name of the currently selected filter to the redux store. This PR aims to accomplish that. 

I only stored the string value of the filter name in the store, but another option is to store the [entire Filter function](https://github.com/Automattic/notifications-panel/blob/master/src/templates/filters.js#L8-L28) for the current selection as well. Forgive me for any redux atrocities committed, still pretty new at this!

**To Test**
* Load the client fresh, you should arrive at the `All` filter by default.
* Changing filters should filter the list just like it used to.