### PR TITLE
Fix unread notes from disappearing when clicked while viewing the unread filter

### DIFF
--- a/src/state/notes/reducer.js
+++ b/src/state/notes/reducer.js
@@ -54,10 +54,23 @@ export const noteLikes = (state = {}, { type, noteId, isLiked }) => {
 export const noteReads = (state = {}, { type, noteId }) =>
     (types.SELECT_NOTE && noteId ? { ...state, [noteId]: true } : state);
 
+export const filteredNoteReads = (state = [], { type, noteId }) => {
+        if (types.SELECT_NOTE === type) {
+            return [ ...state, noteId ];
+        }
+
+        if (types.SET_FILTER === type) {
+            return [];
+        }
+
+        return state;
+};
+
 export default combineReducers({
     allNotes,
     hiddenNoteIds,
     noteApprovals,
     noteLikes,
     noteReads,
+    filteredNoteReads,
 });

--- a/src/state/selectors/get-filtered-note-reads.js
+++ b/src/state/selectors/get-filtered-note-reads.js
@@ -1,5 +1,0 @@
-import getNotes from './get-notes';
-
-export const getFilteredNoteReads = noteState => noteState.filteredNoteReads;
-
-export default (state) => getFilteredNoteReads(getNotes(state));

--- a/src/state/selectors/get-filtered-note-reads.js
+++ b/src/state/selectors/get-filtered-note-reads.js
@@ -1,0 +1,5 @@
+import getNotes from './get-notes';
+
+export const getFilteredNoteReads = noteState => noteState.filteredNoteReads;
+
+export default (state) => getFilteredNoteReads(getNotes(state));

--- a/src/state/selectors/note-has-filtered-read.js
+++ b/src/state/selectors/note-has-filtered-read.js
@@ -1,0 +1,8 @@
+import { includes } from 'lodash';
+
+import getNotes from './get-notes';
+
+export const noteHasFilteredRead = (noteState, noteId) =>
+    includes(noteState.filteredNoteReads, noteId);
+
+export default (state, noteId) => noteHasFilteredRead(getNotes(state), noteId);

--- a/src/templates/filter-bar-controller.js
+++ b/src/templates/filter-bar-controller.js
@@ -1,3 +1,5 @@
+import { includes } from 'lodash';
+
 import Filters from './filters';
 import { store } from '../state';
 import actions from '../state/actions';
@@ -39,7 +41,7 @@ FilterBarController.prototype.getFilteredNotes = function(notes) {
 
     const filteredNoteReads = getFilteredNoteReads(state);
     const filterFunction = (note) =>
-        (filterName === 'unread' && filteredNoteReads.includes(note.id)) || activeTab().filter(note);
+        (filterName === 'unread' && includes(filteredNoteReads, note.id)) || activeTab().filter(note);
 
     return notes.filter(filterFunction);
 };

--- a/src/templates/filter-bar-controller.js
+++ b/src/templates/filter-bar-controller.js
@@ -1,4 +1,4 @@
-import { includes } from 'lodash';
+import { includes, some } from 'lodash';
 
 import Filters from './filters';
 import { store } from '../state';
@@ -40,8 +40,10 @@ FilterBarController.prototype.getFilteredNotes = function(notes) {
     }
 
     const filteredNoteReads = getFilteredNoteReads(state);
-    const filterFunction = (note) =>
-        (filterName === 'unread' && includes(filteredNoteReads, note.id)) || activeTab().filter(note);
+    const filterFunction = (note) => some([
+        'unread' === filterName && includes(filteredNoteReads, note.id),
+        activeTab().filter(note)
+    ]);
 
     return notes.filter(filterFunction);
 };

--- a/src/templates/filter-bar-controller.js
+++ b/src/templates/filter-bar-controller.js
@@ -2,6 +2,7 @@ import Filters from './filters';
 import { store } from '../state';
 import actions from '../state/actions';
 import getFilterName from '../state/selectors/get-filter-name';
+import getFilteredNoteReads from '../state/selectors/get-filtered-note-reads';
 import { bumpStat } from '../rest-client/bump-stat';
 
 var debug = require('debug')('notifications:filterbarcontroller');
@@ -29,13 +30,14 @@ FilterBarController.prototype.selectFilter = function(filterName) {
 };
 
 FilterBarController.prototype.getFilteredNotes = function(notes) {
-    const filterName = getFilterName(store.getState());
+    const state = store.getState();
+    const filterName = getFilterName(state);
     const activeTab = Filters[filterName];
     if (!notes || !activeTab) {
         return [];
     }
 
-    const filteredNoteReads = store.getState().notes.filteredNoteReads;
+    const filteredNoteReads = getFilteredNoteReads(state);
     const filterFunction = (note) =>
         (filterName === 'unread' && filteredNoteReads.includes(note.id)) || activeTab().filter(note);
 

--- a/src/templates/filter-bar-controller.js
+++ b/src/templates/filter-bar-controller.js
@@ -4,7 +4,7 @@ import Filters from './filters';
 import { store } from '../state';
 import actions from '../state/actions';
 import getFilterName from '../state/selectors/get-filter-name';
-import getFilteredNoteReads from '../state/selectors/get-filtered-note-reads';
+import noteHasFilteredRead from '../state/selectors/note-has-filtered-read';
 import { bumpStat } from '../rest-client/bump-stat';
 
 var debug = require('debug')('notifications:filterbarcontroller');
@@ -39,9 +39,8 @@ FilterBarController.prototype.getFilteredNotes = function(notes) {
         return [];
     }
 
-    const filteredNoteReads = getFilteredNoteReads(state);
     const filterFunction = (note) => some([
-        'unread' === filterName && includes(filteredNoteReads, note.id),
+        'unread' === filterName && noteHasFilteredRead(state, note.id),
         activeTab().filter(note)
     ]);
 

--- a/src/templates/filter-bar-controller.js
+++ b/src/templates/filter-bar-controller.js
@@ -29,12 +29,17 @@ FilterBarController.prototype.selectFilter = function(filterName) {
 };
 
 FilterBarController.prototype.getFilteredNotes = function(notes) {
-    const activeTab = Filters[getFilterName(store.getState())];
+    const filterName = getFilterName(store.getState());
+    const activeTab = Filters[filterName];
     if (!notes || !activeTab) {
         return [];
     }
 
-    return notes.filter(activeTab().filter);
+    const filteredNoteReads = store.getState().notes.filteredNoteReads;
+    const filterFunction = (note) =>
+        (filterName === 'unread' && filteredNoteReads.includes(note.id)) || activeTab().filter(note);
+
+    return notes.filter(filterFunction);
 };
 
 export default FilterBarController;


### PR DESCRIPTION
Add a new array that tracks note reads, and when in the unread filter add these notes to the list so that they 'stick' even after you've read them while viewing the filter.

Changing filters will always reset the list.

**To test**
* View the unread filter when it has some unread notes. Clicking on a note should open the detail view, but not remove the note from the list. 
* When you change filters and go back to the unread filter, the notes you read should now be gone.