### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {


### PR DESCRIPTION
**Note**: We shouldn't update to this version in Calypso until https://github.com/Automattic/wp-calypso/pull/14645 is merged.