### PR TITLE
Fix vertical centering.

### DIFF
--- a/src/templates/empty-message.jsx
+++ b/src/templates/empty-message.jsx
@@ -53,7 +53,7 @@ export const EmptyMessage = React.createClass({
         return (
             <div
                 className="wpnc__empty-notes-container"
-                style={{ height: window.innerHeight - TITLE_OFFSET + 'px' }}
+                style={{ height: this.props.height - TITLE_OFFSET + 'px' }}
             >
                 {message}
             </div>

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -312,6 +312,7 @@ export const NoteList = React.createClass({
             notes = (
                 <EmptyMessage
                     emptyMessage={filter.emptyMessage}
+                    height={this.props.height}
                     linkMessage={filter.emptyLinkMessage}
                     link={filter.emptyLink}
                     name={filter.name}


### PR DESCRIPTION
The issue was only with our empty messages (eg. "You're all caught up!") and not the spinner, due to the empty message component's use of `window.innerHeight`. Empty messages height calculations would be off with any height taken up by elements above notifications (like the masterbar). This PR passes the correct calculated height (already used by `NotesList` for the spinner) as a prop to `EmptyMessage`.

![screen shot 2017-06-01 at 10 36 18 am](https://cloud.githubusercontent.com/assets/349751/26692830/f1493586-46b6-11e7-9e61-e20b7eb1775a.png)
_Spinner / Master / This PR_

**Testing**
* Switch to this PR locally.
* Run the repo as standalone to be sure of no regressions.
* In both `packages.json` and `npm-shrinkwrap.json`, change the `"notifications-panel"` value to `"Automattic/notifications-panel#fix\/vertical-centering-3"`.
* `make distclean` and `make run`.
* Check the notifications > Unread tab for spinner and message positioning.

Fixes #113.