### PR TITLE
Fix: Set layout as side-effect

### DIFF
--- a/src/state/action-middleware/ui/index.js
+++ b/src/state/action-middleware/ui/index.js
@@ -25,7 +25,11 @@ export const advanceToNextNote = ({ dispatch, getState }, { noteId }) => {
     }
 };
 
+const toggleDrawer = ({ dispatch }, { noteId }) =>
+    dispatch(actions.ui.setLayout(noteId ? 'widescreen' : 'narrow'));
+
 export default {
+    [types.SELECT_NOTE]: [toggleDrawer],
     [types.SPAM_NOTE]: [advanceToNextNote],
     [types.TRASH_NOTE]: [advanceToNextNote],
 };

--- a/src/templates/summary-in-list.jsx
+++ b/src/templates/summary-in-list.jsx
@@ -23,13 +23,11 @@ export const SummaryInList = React.createClass({
             window.open(this.props.note.url, '_blank');
         } else {
             if (this.props.currentNote == this.props.note.id) {
-                this.props.setLayout('narrow');
                 this.props.unselectNote();
             } else {
                 recordTracksEvent('calypso_notification_note_open', {
                     note_type: this.props.note.type,
                 });
-                this.props.setLayout('widescreen');
                 this.props.selectNote(this.props.note.id);
             }
         }
@@ -70,7 +68,6 @@ export const SummaryInList = React.createClass({
 
 const mapDispatchToProps = dispatch => ({
     selectNote: compose(dispatch, actions.ui.selectNote),
-    setLayout: compose(dispatch, actions.ui.setLayout),
     unselectNote: compose(dispatch, actions.ui.unselectNote),
 });
 


### PR DESCRIPTION
We have previously been setting the layout when clicking
on a notification from the summary list. This set the
widescreen status which would open and close the detail
drawer.

This wasn't triggering however when opening a notification
via the keyboard shortcuts. At least, the drawer wouldn't
open on account of not notifying to the parent window
which screen width setting was set.

This entire system probably needs to be replaced with
actions like `OPEN_DRAWER` or `OPEN_DETAIL_VIEW` or
something like that. We have significant overlap with
`selectedNoteId`

This patch uses a middleware watcher to set the layout
whenever a note is selected or unselected so that it
won't matter how the change happened, just that it did.

**Before/After**
<img src="https://cloud.githubusercontent.com/assets/5431237/26711343/4400bdf8-4725-11e7-9487-47bb6420bc69.gif" width="320" />
<img src="https://cloud.githubusercontent.com/assets/5431237/26711349/511f2718-4725-11e7-9669-7a96f1a8caad.gif" width="320" />

cc: @Automattic/lannister 