### PR TITLE
Fix: Animation after closing open drawer

### DIFF
--- a/standalone/index.js
+++ b/standalone/index.js
@@ -62,7 +62,7 @@ const init = () => {
         'message',
         receiveMessage(({ action, hidden, showing }) => {
             if ('togglePanel' === action) {
-                if (!isShowing && showing) {
+                if (isShowing && !showing) {
                     reset();
                 }
 


### PR DESCRIPTION
Previously there was a bug where the opening animation
for the notes panel would glitch after being closed
with the detail drawer open. This was caused by the
`narrow` layout mode not properly being reset which
left the `widescreen` CSS class still affixed to the
iframe (in standalone mode)

This patch fixes that bug by resetting the app
whenever closing the panel instead of when
opening it.

cc: @Automattic/lannister 