### PR TITLE
Replace anchor markup with <button> for action buttons.

### DIFF
--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -1,4 +1,8 @@
 .wpnc__note-actions {
+	.wpnc__note-actions__buttons {
+		padding-bottom: 16px;
+	}
+
 	.wpnc__reply-box {
 		font-family: $sans;
 		display: block;
@@ -53,12 +57,49 @@
 	}
 }
 
-.wpnc__note-actions__buttons div.wpnc__action-link {
+.wpnc__action-link {
+	background-color: transparent;
+	border: none;
+	box-sizing: border-box;
+	cursor: pointer;
 	display: inline-block;
-	vertical-align: top;
+	font-size: 12px;
 	max-width: 25%;
 	padding: 0 18px;
-	box-sizing: border-box;
+	text-align: center;
+	vertical-align: top;
+
+	&.active-action {
+		color: $orange-jazzy;
+
+		&:hover {
+			color: $gray-text-min;
+
+			.gridicon {
+				fill: $gray;
+			}
+		}
+
+		.gridicon {
+			fill: $orange-jazzy;
+		}
+	}
+
+	&.inactive-action {
+		color: $gray-text-min;
+
+		&:hover {
+			color: $orange-jazzy;
+
+			.gridicon {
+				fill: $orange-jazzy;
+			}
+		}
+
+		.gridicon {
+			fill: $gray;
+		}
+	}
 
 	@media screen and (max-width: 370px) {
 		padding: 0 12px;
@@ -80,51 +121,11 @@
 		padding: 0 18px;
 	}
 
-	p {
-		overflow: hidden;
-	}
-}
-
-.wpnc__main div.wpnc__action-link {
-	cursor: pointer;
-	text-align: center;
-	font-size: 12px;
-	height: 55px;
-
 	.wpnc__noticon {
 		font-size: 24px;
 	}
 
-	.active-action {
-		color: $orange-jazzy;
-
-		&:hover {
-			color: $gray-text-min;
-
-			.gridicon {
-				fill: $gray;
-			}
-		}
-
-		.gridicon {
-			fill: $orange-jazzy;
-		}
+	p {
+		overflow: hidden;
 	}
-
-	.inactive-action {
-		color: $gray-text-min;
-
-		&:hover {
-			color: $orange-jazzy;
-
-			.gridicon {
-				fill: $orange-jazzy;
-			}
-		}
-
-		.gridicon {
-			fill: $gray;
-		}
-	}
-
 }

--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -64,6 +64,10 @@
 		padding: 0 12px;
 	}
 
+	&:focus {
+		outline: none;
+	}
+
 	&:first-child {
 		padding-left: 0;
 	}

--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -75,6 +75,10 @@
 	&:only-child {
 		padding: 0 18px;
 	}
+
+	p {
+		overflow: hidden;
+	}
 }
 
 .wpnc__main div.wpnc__action-link {

--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -91,7 +91,7 @@
 		color: $orange-jazzy;
 
 		&:hover {
-			color: $gray;
+			color: $gray-text-min;
 
 			.gridicon {
 				fill: $gray;
@@ -104,7 +104,7 @@
 	}
 
 	.inactive-action {
-		color: $gray;
+		color: $gray-text-min;
 
 		&:hover {
 			color: $orange-jazzy;

--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -75,34 +75,44 @@
 	&:only-child {
 		padding: 0 18px;
 	}
-
-	a {
-		outline: none;
-	}
-
-	a.inactive-action:hover {
-		color: $orange-jazzy;
-	}
-
-	a.active-action:hover {
-		color: $gray-text-min;
-	}
 }
 
 .wpnc__main div.wpnc__action-link {
+	cursor: pointer;
 	text-align: center;
 	font-size: 12px;
+	height: 55px;
 
 	.wpnc__noticon {
 		font-size: 24px;
 	}
 
-	a.active-action {
+	.active-action {
 		color: $orange-jazzy;
+
+		&:hover {
+			color: $gray;
+
+			.gridicon {
+				fill: $gray;
+			}
+		}
+
+		.gridicon {
+			fill: $orange-jazzy;
+		}
 	}
 
-	a.inactive-action {
-		color: $gray-text-min;
+	.inactive-action {
+		color: $gray;
+
+		&:hover {
+			color: $orange-jazzy;
+
+			.gridicon {
+				fill: $orange-jazzy;
+			}
+		}
 
 		.gridicon {
 			fill: $gray;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -532,12 +532,6 @@ body {
       	-webkit-overflow-scrolling: touch;
     	}
 
-    	.wpnc__action-link {
-    		p {
-    			overflow: hidden;
-    		}
-    	}
-
     	.wpnc__user {
     		p {
     			@extend %ellipsy-box;

--- a/src/templates/action-button.jsx
+++ b/src/templates/action-button.jsx
@@ -25,14 +25,13 @@ const ActionButton = React.createClass({
         return (
             <HotkeyContainer shortcuts={hotkeys}>
                 <div className="wpnc__action-link">
-                    <a
-                        href="#"
+                    <div
                         className={isActive ? 'active-action' : 'inactive-action'}
                         title={title}
                         onClick={onToggle}
                     >
                         <Gridicon icon={icon} size={24} /><p>{text}</p>
-                    </a>
+                    </div>
                 </div>
             </HotkeyContainer>
         );

--- a/src/templates/action-button.jsx
+++ b/src/templates/action-button.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -24,15 +25,13 @@ const ActionButton = React.createClass({
 
         return (
             <HotkeyContainer shortcuts={hotkeys}>
-                <div className="wpnc__action-link">
-                    <div
-                        className={isActive ? 'active-action' : 'inactive-action'}
-                        title={title}
-                        onClick={onToggle}
-                    >
-                        <Gridicon icon={icon} size={24} /><p>{text}</p>
-                    </div>
-                </div>
+				<button
+					className={classNames( 'wpnc__action-link', isActive ? 'active-action' : 'inactive-action' )}
+					title={title}
+					onClick={onToggle}
+				>
+					<Gridicon icon={icon} size={24} /><p>{text}</p>
+				</button>
             </HotkeyContainer>
         );
     },


### PR DESCRIPTION
This prevents event propagation when an action is clicked, which can trigger a "You have unsaved changes" browser alert.

Also fixes a styling bug where the text and gridicons of actions would be different colors on hover.

![screen shot 2017-06-05 at 12 56 05 pm](https://cloud.githubusercontent.com/assets/349751/26800752/43ec36f4-49ef-11e7-9183-a5fde7d88f06.png)
_Before_
![screen shot 2017-06-05 at 12 55 51 pm](https://cloud.githubusercontent.com/assets/349751/26800772/4ec60c62-49ef-11e7-8881-ebd867369578.png)
_After_

Fixes https://github.com/Automattic/wp-calypso/issues/14071.