### PR TITLE
Remove back arrow noticon

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -76,12 +76,10 @@ body {
     		display: inline;
     		float: left;
 
-    		&:before {
-    			@extend %wpnc__noticon;
-    			content: '\f431';
-    			transform: rotate( 90deg );
-    			vertical-align: middle;
-    		}
+				.gridicon {
+					margin-right: 4px;
+					vertical-align: -4px;
+				}
     	}
 
     	.wpnc__prev,

--- a/src/templates/button-back.jsx
+++ b/src/templates/button-back.jsx
@@ -7,6 +7,11 @@ import { localize } from 'i18n-calypso';
 
 import actions from '../state/actions';
 
+/**
+ * Internal dependencies
+ */
+import Gridicon from './gridicons';
+
 const routeBack = (global, unselectNote) => event => {
     event.preventDefault();
     global.input.lastInputWasKeyboard = false;
@@ -20,9 +25,11 @@ export const BackButton = ({ global, isEnabled, translate, unselectNote }) => {
 
     return isEnabled
         ? <a className="wpnc__back" onClick={routeBack(global, unselectNote)} href="#">
+              <Gridicon icon="arrow-left" size={18} />
               {backText}
           </a>
         : <a className="wpnc__back disabled" disabled="disabled" href="#">
+              <Gridicon icon="arrow-left" size={18} />
               {backText}
           </a>;
 };

--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -159,16 +159,6 @@ export default React.createClass({
                     </svg>
                 );
 
-            case 'gridicons-reblog':
-                return (
-                    <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                        <title>Reblog</title>
-                        <g>
-                            <path d="M22.086 9.914L20 7.828V18c0 1.105-.895 2-2 2h-7v-2h7V7.828l-2.086 2.086L14.5 8.5 19 4l4.5 4.5-1.414 1.414zM6 16.172V6h7V4H6c-1.105 0-2 .895-2 2v10.172l-2.086-2.086L.5 15.5 5 20l4.5-4.5-1.414-1.414L6 16.172z" />
-                        </g>
-                    </svg>
-                );
-
             case 'gridicons-trophy':
                 return (
                     <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">


### PR DESCRIPTION
Replaced the noticon with a gridicon back arrow.

Also removed some duplicated svg code.

Before:

![screen shot 2017-06-06 at 10 53 32 am](https://user-images.githubusercontent.com/618551/26838681-6d160ca0-4aa6-11e7-884d-336cc8cb2666.png)

After:

![screen shot 2017-06-06 at 10 53 12 am](https://user-images.githubusercontent.com/618551/26838687-72f369ba-4aa6-11e7-999f-f0ae16523a66.png)
