### PR TITLE
Tidy up event propagation of anchors.

### DIFF
--- a/src/templates/button-back.jsx
+++ b/src/templates/button-back.jsx
@@ -13,6 +13,7 @@ import actions from '../state/actions';
 import Gridicon from './gridicons';
 
 const routeBack = (global, unselectNote) => event => {
+    event.stopPropagation();
     event.preventDefault();
     global.input.lastInputWasKeyboard = false;
     unselectNote();
@@ -24,11 +25,11 @@ export const BackButton = ({ global, isEnabled, translate, unselectNote }) => {
     });
 
     return isEnabled
-        ? <a className="wpnc__back" onClick={routeBack(global, unselectNote)} href="#">
+        ? <a className="wpnc__back" onClick={routeBack(global, unselectNote)}>
               <Gridicon icon="arrow-left" size={18} />
               {backText}
           </a>
-        : <a className="wpnc__back disabled" disabled="disabled" href="#">
+        : <a className="wpnc__back disabled" disabled="disabled">
               <Gridicon icon="arrow-left" size={18} />
               {backText}
           </a>;

--- a/src/templates/nav-button.jsx
+++ b/src/templates/nav-button.jsx
@@ -16,7 +16,6 @@ export const NavButton = React.createClass({
                     disabled: !this.props.isEnabled,
                 })}
                 disabled={!this.props.isEnabled}
-                href="#"
                 onClick={this.props.isEnabled ? this.navigate : null}
             />
         );

--- a/src/templates/summary-in-single.jsx
+++ b/src/templates/summary-in-single.jsx
@@ -65,7 +65,7 @@ var UserHeader = React.createClass({
                 );
             } else {
                 return (
-                    <a className={classNames + ' disabled'} href="#" disabled="disabled">
+                    <a className={classNames + ' disabled'} disabled="disabled">
                         {children}
                     </a>
                 );


### PR DESCRIPTION
Noting our distinction of [when to use anchors vs. button elements](https://github.com/Automattic/notifications-panel/pull/133#issuecomment-306546364), this PR tidies up some unnecessary `href` attributes, while ensuring no event bubbling when clicking the Back button. This also guards more anchors against the original issue in Automattic/wp-calypso#14071.