### PR TITLE
Use button elements instead of anchors for actions.

### DIFF
--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -41,6 +41,7 @@
 			font-size: 12px;
 		}
 		button.active {
+			display: block;
 			color: $blue-medium;
 		}
 		button.inactive {

--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -56,7 +56,7 @@
 	}
 }
 
-.wpnc__action-link {
+.wpnc__main .wpnc__action-link {
 	background-color: transparent;
 	border: none;
 	box-sizing: border-box;

--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -25,11 +25,11 @@
 			resize: vertical;
 		}
 
-		textarea:focus + a {
+		textarea:focus + button {
 			display: block;
 		}
 
-		a {
+		button {
 			font-family: $sans;
 			color: $gray;
 			display: none;
@@ -40,11 +40,10 @@
 			font-weight: 600;
 			font-size: 12px;
 		}
-		a.active {
-			display: block;
+		button.active {
 			color: $blue-medium;
 		}
-		a.inactive {
+		button.inactive {
 			cursor: default;
 		}
 

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -44,6 +44,18 @@ body {
     	color: $gray;
     }
 
+    button {
+		background-color: transparent;
+		border: none;
+		cursor: pointer;
+		font-size: inherit;
+		padding: 0;
+
+		&.focus {
+			outline: none;
+		}
+	}
+
     header {
     	border-bottom: 1px solid lighten( $gray, 30 );
     	box-sizing: border-box;

--- a/src/templates/comment-reply-input.jsx
+++ b/src/templates/comment-reply-input.jsx
@@ -295,24 +295,23 @@ const CommentReplyInput = React.createClass({
                     context: 'verb: imperative',
                 });
                 submitLink = (
-                    <a
-                        href="#"
+                    <button
                         title={submitLinkTitle}
                         className="active"
                         onClick={this.handleSubmit}
                         onKeyDown={this.handleSendEnter}
                     >
                         {sendText}
-                    </a>
+                    </button>
                 );
             } else {
                 var submitLinkTitle = this.props.translate(
                     'Write your response in order to submit'
                 );
                 submitLink = (
-                    <a href="#" title={submitLinkTitle} className="inactive">
+                    <button title={submitLinkTitle} className="inactive">
                         {sendText}
-                    </a>
+                    </button>
                 );
             }
         }

--- a/src/templates/follow-link.jsx
+++ b/src/templates/follow-link.jsx
@@ -74,10 +74,10 @@ export const FollowLink = React.createClass({
         }
 
         return (
-            <a className="follow-link" onClick={this.toggleFollowStatus} href="#">
+            <button className="follow-link" onClick={this.toggleFollowStatus}>
                 <Gridicon icon={gridicon_icon} size={18} />
                 {link_text}
-            </a>
+            </button>
         );
     },
 });

--- a/src/templates/undo-list-item.jsx
+++ b/src/templates/undo-list-item.jsx
@@ -190,9 +190,9 @@ export const UndoListItem = React.createClass({
                 style={isVisible}
             >
                 <p>
-                    <a href="#" className="wpnc__undo-link" onClick={this.cancelAction}>
+                    <button className="wpnc__undo-link" onClick={this.cancelAction}>
                         {undo_text}
-                    </a>
+                    </button>
                     <span className="wpnc__undo-message">{message}</span>
                     <span className="wpnc__close-link wpnc__noticon" onClick={this.actImmediately}>
                         


### PR DESCRIPTION
Noting that we want to use [anchors for navigation and buttons for actions](https://github.com/Automattic/notifications-panel/pull/133#issuecomment-306546364), this PR corrects any instances of anchors that should instead be buttons.

The following three visual elements are affected:

![screen shot 2017-06-06 at 12 48 15 pm](https://user-images.githubusercontent.com/349751/26848791-82acbeaa-4ab6-11e7-8cb5-e1dc1d7fa1df.png)
_Comment reply SEND button_

![screen shot 2017-06-06 at 12 49 31 pm](https://user-images.githubusercontent.com/349751/26848821-a3f2cfa0-4ab6-11e7-98d9-f440f554111c.png)
_Follow button_

![screen shot 2017-06-06 at 12 50 27 pm](https://user-images.githubusercontent.com/349751/26848887-ec551f6e-4ab6-11e7-91eb-d91f0d1391b3.png)
![screen shot 2017-06-06 at 12 51 20 pm](https://user-images.githubusercontent.com/349751/26848895-f19ff23c-4ab6-11e7-97fa-b76c7bc3794c.png)
_The Trash and Spam actions_

**Testing**
* Open both a notifications standalone window with this PR, and a WordPress.com tab.
* Compare the three elements above, and be sure there are no functional or styling regressions.