### PR TITLE
Replace cross noticon

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -486,7 +486,7 @@ body {
     	}
 
     	.wpnc__noticon {
-    		@extend %wpnc__noticon;
+				display: inline-block;
     	}
 
     	.wpnc__close-link {

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -485,10 +485,6 @@ body {
     		margin-left: 2em;
     	}
 
-    	.wpnc__noticon {
-				display: inline-block;
-    	}
-
     	.wpnc__close-link {
     		width: 44px;
     		height: 100%;

--- a/src/boot/stylesheets/overlay-bars.scss
+++ b/src/boot/stylesheets/overlay-bars.scss
@@ -9,7 +9,7 @@
 	background-color: $alert-red;
 	color: $white;
 
-    @media only screen and (min-width: 800px) {
+  @media only screen and (min-width: 800px) {
 		width: 400px;
 	}
 
@@ -26,17 +26,17 @@
 		color: $white;
 	}
 
-	.wpnc__noticon {
-		@extend %wpnc__noticon;
+	.wpnc__status-bar__wpnc__close-link {
+		display: inline-block;
+
+		.gridicon {
+			vertical-align: middle;
+		}
 	}
 
-    span {
-        margin: 15px 5px 15px 5px;
-    }
-
-    .wpnc__status-bar__wpnc__close-link {
-        font-size: 22px;
-    }
+  span {
+		margin: 15px 5px 15px 5px;
+  }
 }
 
 .wpnc__status-bar.success {

--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -229,6 +229,16 @@ export default React.createClass({
                     </svg>
                 );
 
+            case 'gridicons-cross':
+                return (
+                    <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <title>Cross</title>
+                        <g>
+                          <path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"/>
+                        </g>
+                    </svg>
+                );
+
             case 'gridicons-cog':
                 return (
                     <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/src/templates/status-bar.jsx
+++ b/src/templates/status-bar.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import Gridicon from './gridicons';
+
 export const StatusBar = React.createClass({
     getDefaultProps: function() {
         return {
@@ -64,10 +66,10 @@ export const StatusBar = React.createClass({
                     }}
                 />
                 <span
-                    className="wpnc__status-bar__wpnc__close-link wpnc__noticon"
+                    className="wpnc__status-bar__wpnc__close-link"
                     onClick={this.disappear}
                 >
-                    
+                    <Gridicon icon="cross" size={18} />
                 </span>
             </div>
         );

--- a/src/templates/undo-list-item.jsx
+++ b/src/templates/undo-list-item.jsx
@@ -9,6 +9,8 @@ import getSelectedNoteId from '../state/selectors/get-selected-note-id';
 
 import { bumpStat } from '../rest-client/bump-stat';
 
+import Gridicon from './gridicons';
+
 var { recordTracksEvent } = require('../helpers/stats');
 
 const KEY_U = 85;
@@ -195,7 +197,7 @@ export const UndoListItem = React.createClass({
                     </a>
                     <span className="wpnc__undo-message">{message}</span>
                     <span className="wpnc__close-link wpnc__noticon" onClick={this.actImmediately}>
-                        
+                        <Gridicon icon="cross" size={24} />
                     </span>
                 </p>
             </div>

--- a/src/templates/undo-list-item.jsx
+++ b/src/templates/undo-list-item.jsx
@@ -196,7 +196,7 @@ export const UndoListItem = React.createClass({
                         {undo_text}
                     </a>
                     <span className="wpnc__undo-message">{message}</span>
-                    <span className="wpnc__close-link wpnc__noticon" onClick={this.actImmediately}>
+                    <span className="wpnc__close-link" onClick={this.actImmediately}>
                         <Gridicon icon="cross" size={24} />
                     </span>
                 </p>


### PR DESCRIPTION
Replaced noticon for the undo message. To test, delete a comment.

Replaced cross noticon for the status message. To test, reply to a comment.

Before:

![screen shot 2017-06-06 at 2 55 43 pm](https://user-images.githubusercontent.com/618551/26849104-7efcc69e-4ac8-11e7-9ad5-9fd551d144ec.png)
![screen shot 2017-06-06 at 2 58 36 pm](https://user-images.githubusercontent.com/618551/26849198-db2043e2-4ac8-11e7-8bb4-15816af2d113.png)


After:

![screen shot 2017-06-06 at 2 55 28 pm](https://user-images.githubusercontent.com/618551/26849114-8c2c53e8-4ac8-11e7-997a-dd5c4848b2a8.png)
![screen shot 2017-06-06 at 2 58 52 pm](https://user-images.githubusercontent.com/618551/26849205-e30786a6-4ac8-11e7-8108-1583483d1e91.png)

