### PR TITLE
Replace close link anchors with button elements.

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -488,15 +488,10 @@ body {
     	.wpnc__undo-message {
     		margin-left: 2em;
     	}
-
-    	.wpnc__close-link {
-    		width: 44px;
-    		height: 100%;
-    		line-height: 20px;
-    	}
     }
 
     .wpnc__close-link {
+		color: $white;
     	position: absolute;
     	right: 10px;
     	cursor: pointer;

--- a/src/boot/stylesheets/overlay-bars.scss
+++ b/src/boot/stylesheets/overlay-bars.scss
@@ -9,10 +9,6 @@
 	background-color: $alert-red;
 	color: $white;
 
-  @media only screen and (min-width: 800px) {
-		width: 400px;
-	}
-
 	a,
 	a:visited {
 		color: $white;
@@ -26,17 +22,13 @@
 		color: $white;
 	}
 
-	.wpnc__status-bar__wpnc__close-link {
-		display: inline-block;
-
-		.gridicon {
-			vertical-align: middle;
-		}
+	span {
+		margin: 15px 5px 15px 5px;
 	}
 
-  span {
-		margin: 15px 5px 15px 5px;
-  }
+	.wpnc__close-link {
+		position: relative;
+	}
 }
 
 .wpnc__status-bar.success {

--- a/src/templates/status-bar.jsx
+++ b/src/templates/status-bar.jsx
@@ -65,12 +65,12 @@ export const StatusBar = React.createClass({
                         __html: this.props.statusMessage,
                     }}
                 />
-                <span
-                    className="wpnc__status-bar__wpnc__close-link"
+                <button
+                    className="wpnc__close-link"
                     onClick={this.disappear}
                 >
                     <Gridicon icon="cross" size={18} />
-                </span>
+                </button>
             </div>
         );
     },

--- a/src/templates/undo-list-item.jsx
+++ b/src/templates/undo-list-item.jsx
@@ -196,9 +196,9 @@ export const UndoListItem = React.createClass({
                         {undo_text}
                     </button>
                     <span className="wpnc__undo-message">{message}</span>
-                    <span className="wpnc__close-link" onClick={this.actImmediately}>
+                    <button className="wpnc__close-link" onClick={this.actImmediately}>
                         <Gridicon icon="cross" size={24} />
-                    </span>
+                    </button>
                 </p>
             </div>
         );


### PR DESCRIPTION
Following from #132 , this replaces the close `X` anchors with buttons. There are further markup differences between the two instances (the overlay uses `flex`, while the other does not), but they could be better dealt with in a separate PR.

This PR also addresses a visual bug where the overlay notice doesn't extend the full width of its container:

![screen shot 2017-06-07 at 12 17 29 pm](https://user-images.githubusercontent.com/349751/26898286-248ee814-4b80-11e7-910a-6a2056369780.png)
_Before_

![screen shot 2017-06-07 at 12 51 26 pm](https://user-images.githubusercontent.com/349751/26898305-2dd03612-4b80-11e7-9734-9913c0a368ea.png)
_After_

