### PR TITLE
Remove noticon extends

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -397,7 +397,8 @@ body {
     		}
 
     		.wpnc__subject .wpnc__noticon {
-    			@extend %wpnc__noticon;
+    			line-height: 1;
+					vertical-align: -3px;
     			color: $gray;
     			padding: 2px 5px 0 0;
     		}
@@ -572,8 +573,11 @@ body {
     		border-bottom: 1px solid lighten( $gray, 30 );
 
     		.wpnc__noticon {
-    			@extend %wpnc__noticon;
     			padding: 0 10px;
+
+					.gridicon {
+						vertical-align: top;
+					}
     		}
 
     		a {

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -267,10 +267,12 @@ body {
     	}
 
     	.wpnc__note-icon .wpnc__noticon {
-    		@extend %wpnc__noticon;
-    		text-decoration: none;
+				display: flex;
+				align-items: center;
+				justify-content: center;
     		color: white;
-    		padding: 3px;
+				height: 22px;
+				width: 22px;
     		border: {
     			width: 2px;
     			style: solid;
@@ -361,8 +363,8 @@ body {
 
     	.wpnc__note-icon .wpnc__noticon {
     		position: absolute;
-    		bottom: -.333em;
-    		right: -.5em;
+    		bottom: -5px;
+    		right: -8px;
     		background-color: lighten( $gray, 5% );
     		border-color: $white;
     	}

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -144,9 +144,6 @@ body {
     	font-size: $capital-font-size;
     }
 
-    .rtl header .back:before {
-    }
-
     .rtl header .back:after {
     	transform: rotate( 90deg );
     }

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -145,12 +145,9 @@ body {
     }
 
     .rtl header .back:before {
-    	content: none;
     }
 
     .rtl header .back:after {
-    	@extend %wpnc__noticon;
-    	content: '\f432';
     	transform: rotate( 90deg );
     }
 

--- a/src/boot/stylesheets/shared/extends.scss
+++ b/src/boot/stylesheets/shared/extends.scss
@@ -1,23 +1,3 @@
-%clear-text {
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-
-%wpnc__noticon {
-	@extend %clear-text;
-	display: inline-block;
-	font: normal 16px/1 'Noticons';
-	vertical-align: top;
-}
-
-%wpnc__bignoticon {
-	@extend %clear-text;
-	display: inline-block;
-	font: normal 18px/1 'Noticons';
-	font-weight: bold;
-	vertical-align: middle;
-}
-
 %container {
 	&:after {
 		content: ".";


### PR DESCRIPTION
This PR removes the use of the noticon extend, which previously provided an easy way to style the noticon icon font.

Should be no visual change, other than maybe a 1px difference.

Some elements depended on some of the noticon extend styles though:

```
	display: inline-block;
	font: normal 16px/1 'Noticons';
	vertical-align: top;
```

I went through each use of the extend and made sure it looked the same after removal. For most things, I had to add some styles back in, like vertical align.

Most notable changes:

- icon bubble
- 'has reply' icons

![screen shot 2017-06-07 at 3 32 43 pm](https://user-images.githubusercontent.com/618551/26900032-920dcde0-4b96-11e7-9fa4-87dd3f763d8e.png)

![screen shot 2017-06-07 at 3 32 58 pm](https://user-images.githubusercontent.com/618551/26900039-9a1bb056-4b96-11e7-9966-33b21bac9b7e.png)
