### PR TITLE
Fix: Note reads across browser sessions, <Note> cleanup

### DIFF
--- a/src/rest-client/index.js
+++ b/src/rest-client/index.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-import { difference, get, max, pick, property, range } from 'lodash';
+import { difference, get, pick, property, range } from 'lodash';
 
 import { store } from '../state';
 import actions from '../state/actions';
@@ -459,6 +459,13 @@ function handleStorageEvent(event) {
                 });
             }
         } catch (e) {}
+        return;
+    }
+
+    if ('note_read_status_' === event.key.substring(0, 17)) {
+        const noteId = parseInt(event.key.slice(17), 10);
+
+        return store.dispatch(actions.notes.readNote(noteId));
     }
 }
 

--- a/src/state/action-types.js
+++ b/src/state/action-types.js
@@ -6,6 +6,7 @@ export const NOTES_REMOVE = 'NOTES_REMOVE';
 export const NOTES_LOADING = 'NOTES_LOADING';
 export const NOTES_LOADED = 'NOTES_LOADED';
 export const SELECT_NOTE = 'SELECT_NOTE';
+export const READ_NOTE = 'READ_NOTE';
 export const RESET_LOCAL_APPROVAL = 'RESET_LOCAL_APPROVAL';
 export const RESET_LOCAL_LIKE = 'RESET_LOCAL_LIKE';
 export const SET_IS_SHOWING = 'SET_IS_SHOWING'; // special! do not use

--- a/src/state/notes/actions.js
+++ b/src/state/notes/actions.js
@@ -15,6 +15,7 @@ export const noteAction = action => noteId => ({
     noteId,
 });
 
+export const readNote = noteAction(types.READ_NOTE);
 export const spamNote = noteAction(types.SPAM_NOTE);
 export const trashNote = noteAction(types.TRASH_NOTE);
 
@@ -70,6 +71,7 @@ export default {
     addNotes,
     approveNote,
     likeNote,
+    readNote,
     removeNotes,
     resetLocalApproval,
     resetLocalLike,

--- a/src/state/notes/reducer.js
+++ b/src/state/notes/reducer.js
@@ -51,8 +51,13 @@ export const noteLikes = (state = {}, { type, noteId, isLiked }) => {
     return state;
 };
 
-export const noteReads = (state = {}, { type, noteId }) =>
-    (types.SELECT_NOTE && noteId ? { ...state, [noteId]: true } : state);
+export const noteReads = (state = {}, { type, noteId }) => {
+    if ((types.READ_NOTE === type || types.SELECT_NOTE === type) && noteId) {
+        return { ...state, [noteId]: true };
+    }
+
+    return state;
+};
 
 export const filteredNoteReads = (state = [], { type, noteId }) => {
     if (types.SELECT_NOTE === type) {

--- a/src/templates/index.jsx
+++ b/src/templates/index.jsx
@@ -566,6 +566,4 @@ const mapDispatchToProps = {
     unselectNote: actions.ui.unselectNote,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps, null, {
-    pure: false,
-})(Layout);
+export default connect(mapStateToProps, mapDispatchToProps)(Layout);


### PR DESCRIPTION
Resolves #130

In the earlier versions of the app we used stateful updates to the React
render and relied on storage events to communicate between sessions that
notes were being read. This led to re-renders reflecting those changes
by listening to the `ready` event from `rest-client`.

With the introduction of Redux and the removal of those event-emitters
we lost this functionality and notes weren't being marked read. Further,
because we were still tied to the _impure_ render modes the note
component wasn't updating even when state was.

Now, upon retrieval of such a storage message we are marking the note as
read via a dispatched action. The relevant components are now no longer
marked as _impure_ and will update on all state changes.

Interestingly enough an old `shouldComponentUpdate` functionw was
preventing updates because it wasn't comparing against `getNoteIsRead()`
(since it's now separate from the note object).

**Testing**

See #130 - open two browser tabs/sessions and read a note in one of them. In **master** it should not carry over but in this branch it should update practically instantly in both or all sessions.