### PR TITLE
Rename class names to gridicons

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -10,7 +10,6 @@
 	<meta name="node-version" content="<%= htmlWebpackPlugin.options.nodePlatform %>">
 	<meta name="git-describe" content="<%= htmlWebpackPlugin.options.gitDescribe %>">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese">
-	<link rel="stylesheet" href="https://s1.wp.com/i/noticons/noticons.css">
 </head>
 <body>
 <div class="wpnc__main"></div>

--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -121,7 +121,7 @@
 		padding: 0 18px;
 	}
 
-	.wpnc__noticon {
+	.wpnc__gridicon {
 		font-size: 24px;
 	}
 

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -272,7 +272,7 @@ body {
     		height: $icon-size;
     	}
 
-    	.wpnc__note-icon .wpnc__noticon {
+    	.wpnc__note-icon .wpnc__gridicon {
 				display: flex;
 				align-items: center;
 				justify-content: center;
@@ -367,7 +367,7 @@ body {
     		cursor: pointer;
     	}
 
-    	.wpnc__note-icon .wpnc__noticon {
+    	.wpnc__note-icon .wpnc__gridicon {
     		position: absolute;
     		bottom: -5px;
     		right: -8px;
@@ -379,12 +379,12 @@ body {
     		border-radius: 50%;
     	}
 
-    	.unread .wpnc__note-icon .wpnc__noticon {
+    	.unread .wpnc__note-icon .wpnc__gridicon {
     		background: $blue-medium;
     		border-color: $gray-light;
     	}
 
-    	.wpnc__comment-unapproved .wpnc__note-icon .wpnc__noticon {
+    	.wpnc__comment-unapproved .wpnc__note-icon .wpnc__gridicon {
     		background: $alert-yellow;
     		border-color: $alert-yellow-lighter;
     	}
@@ -408,7 +408,7 @@ body {
     			@extend %ellipsy-box;
     		}
 
-    		.wpnc__subject .wpnc__noticon {
+    		.wpnc__subject .wpnc__gridicon {
     			line-height: 1;
 					vertical-align: -3px;
     			color: $gray;
@@ -579,7 +579,7 @@ body {
     		padding: $padding-medium 0;
     		border-bottom: 1px solid lighten( $gray, 30 );
 
-    		.wpnc__noticon {
+    		.wpnc__gridicon {
     			padding: 0 10px;
 
 					.gridicon {
@@ -603,7 +603,7 @@ body {
     		border: none;
     	}
 
-    	.wpnc__note-icon .wpnc__noticon {
+    	.wpnc__note-icon .wpnc__gridicon {
     		font-size: 2em;
     		background-color: lighten( $gray, 20 );
     		border-color: lighten( $gray, 20 );

--- a/src/indices-to-html/index.js
+++ b/src/indices-to-html/index.js
@@ -26,7 +26,7 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
         type_mappings = {
             b: 'strong', // be strong, my friend
             i: 'em', // I am, don't worry
-			noticon: 'gridicon',
+            noticon: 'gridicon',
         };
 
         // Replace unwanted tags with more popular and cool ones

--- a/src/indices-to-html/index.js
+++ b/src/indices-to-html/index.js
@@ -26,6 +26,7 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
         type_mappings = {
             b: 'strong', // be strong, my friend
             i: 'em', // I am, don't worry
+			noticon: 'gridicon',
         };
 
         // Replace unwanted tags with more popular and cool ones
@@ -33,7 +34,7 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
             range_info_type = type_mappings[range_info.type];
         }
 
-        new_classes.push(`wpnc__${range_info.type}`);
+        new_classes.push(`wpnc__${range_info_type}`);
     }
 
     // We want to do different things depending on the range type.
@@ -77,8 +78,8 @@ function render_range(new_sub_text, new_sub_range, range_info, range_data, optio
             new_container = document.createElement(range_info_type);
             build_chunks(new_sub_text, new_sub_range, range_data, new_container, options);
             break;
-        case 'noticon':
-            // Noticons have special text, and are thus not recursed into
+        case 'gridicon':
+            // Gridicons have special text, and are thus not recursed into
             new_container = document.createElement('span');
             new_container.innerHTML = ReactDOMServer.renderToStaticMarkup(
                 React.createElement(Gridicon, {

--- a/src/templates/body.jsx
+++ b/src/templates/body.jsx
@@ -154,7 +154,7 @@ export const NoteBody = React.createClass({
 
             replyBlock = (
                 <div className="wpnc__reply">
-                    <span className="wpnc__noticon"></span>
+                    <span className="wpnc__gridicon"></span>
                     {replyMessage}
                 </div>
             );

--- a/src/templates/summary-in-list.jsx
+++ b/src/templates/summary-in-list.jsx
@@ -52,7 +52,7 @@ export const SummaryInList = React.createClass({
                             <img src="https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=128" />
                         }
                     />
-                    <span className="wpnc__noticon">
+                    <span className="wpnc__gridicon">
                         <Gridicon icon={noticon2gridicon(this.props.note.noticon)} size={16} />
                     </span>
 


### PR DESCRIPTION
This finally removes noticons and the link to the noticons css file.

There is one last classname that I can't figure out `wpnc__noticon`

![screen shot 2017-06-08 at 11 08 13 am](https://user-images.githubusercontent.com/618551/26938838-0fc079be-4c3b-11e7-8df8-26f167932d0a.png)

![screen shot 2017-06-08 at 11 11 55 am](https://user-images.githubusercontent.com/618551/26938936-53085e1c-4c3b-11e7-892a-fcd3b3845948.png)


I believe it's being created here:

src/indices-to-html/index.js

but I can't make sense of the code.