### PR TITLE
Update the single view header navigation markup.

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -39,20 +39,18 @@ body {
     	color: $blue-wordpress;
     }
 
-    a[disabled], .wpnc__single-view header .back[disabled] {
-    	pointer-events: none;
-    	color: $gray;
-    }
-
     button {
 		background-color: transparent;
 		border: none;
+		color: $blue-wordpress;
 		cursor: pointer;
 		font-size: inherit;
+		outline: none;
 		padding: 0;
 
-		&.focus {
-			outline: none;
+		&[disabled] {
+			pointer-events: none;
+			color: $gray;
 		}
 	}
 
@@ -81,6 +79,10 @@ body {
     		color: darken( $gray, 10% );
     		display: inline;
     	}
+
+		button {
+			line-height: 38px;
+		}
 
     	.wpnc__back {
     		@extend %headertext;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -49,8 +49,8 @@ body {
 		padding: 0;
 
 		&[disabled] {
-			pointer-events: none;
 			color: $gray;
+			cursor: default;
 		}
 	}
 

--- a/src/templates/button-back.jsx
+++ b/src/templates/button-back.jsx
@@ -25,14 +25,14 @@ export const BackButton = ({ global, isEnabled, translate, unselectNote }) => {
     });
 
     return isEnabled
-        ? <a className="wpnc__back" onClick={routeBack(global, unselectNote)}>
+        ? <button className="wpnc__back" onClick={routeBack(global, unselectNote)}>
               <Gridicon icon="arrow-left" size={18} />
               {backText}
-          </a>
-        : <a className="wpnc__back disabled" disabled="disabled">
+          </button>
+        : <button className="wpnc__back disabled" disabled="disabled">
               <Gridicon icon="arrow-left" size={18} />
               {backText}
-          </a>;
+          </button>;
 };
 
 BackButton.propTypes = {

--- a/src/templates/nav-button.jsx
+++ b/src/templates/nav-button.jsx
@@ -19,16 +19,15 @@ export const NavButton = React.createClass({
 
     render() {
         return (
-            <a
+            <button
                 className={classNames(this.props.className, {
                     disabled: !this.props.isEnabled,
                 })}
                 disabled={!this.props.isEnabled}
                 onClick={this.props.isEnabled ? this.navigate : null}
             >
-              <Gridicon icon={this.props.iconName} size={18} />
-            </a>
-
+                <Gridicon icon={this.props.iconName} size={18} />
+            </button>
         );
     },
 });


### PR DESCRIPTION
This PR uses `<button>` instead of anchors for the single view header navigation markup.

No visible regressions should be seen.