### PR TITLE
Fix: pre-commit hook wasn't prettifying files

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -4,7 +4,7 @@ PATH="$PATH:/usr/local/bin"
 
 printf "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n"
 
-files=$(git diff --cached --name-only --diff-filter=ACM | grep "(src|standalone)/.*\.js\?")
+files=$(git diff --cached --name-only --diff-filter=ACM | grep -E "(src|standalone).*\.js?")
 if [ "$files" = "" ]; then
 	printf "\nNo files changed\n"
     exit 0


### PR DESCRIPTION
Resolves #147

It was discovered that no files were being prettified because the line
grabbing changed files always returned an empty result set.

The problem stemmed from the syntax of the Regular Expression in `grep`
and has been resolved by updating and adding the `-E` flag to accept
alternation groups.

Thanks @kwight for your sleuthing on this!

cc: @Automattic/lannister 