### PR TITLE
Fix filter missing border/pixel shift when running in iframe #131

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -165,22 +165,17 @@ body {
     	background-color: $white;
     	color: $gray-text-min;
     	border-bottom: 1px solid lighten( $gray, 30 );
+        border-left: 1px solid $white;
     	text-align: center; // Center filter in IE 9
     	height: $filter-height;
     	box-sizing: border-box;
     	direction: ltr;
     	display: table; //fallback for browsers not supporting flexbox
-
-		@media only screen and (min-width: 661px) {
-			border-left: 1px solid $white;
-		}
     }
 
-	@media only screen and (min-width: 661px) {
-	    .wpnc__note-list:not(.is-note-open) .wpnc__filter {
-	    	border-left: 1px solid lighten( $gray, 30 );
-	    }
-	}
+    .wpnc__note-list:not(.is-note-open) .wpnc__filter {
+    	border-left: 1px solid lighten( $gray, 30 );
+    }
 
     .wpnc__filter__segmented-control {
     	display: table-row; // fallback for browsers not supporting flexbox.

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -165,7 +165,7 @@ body {
     	background-color: $white;
     	color: $gray-text-min;
     	border-bottom: 1px solid lighten( $gray, 30 );
-        border-left: 1px solid $white;
+    	border-left: 1px solid $white;
     	text-align: center; // Center filter in IE 9
     	height: $filter-height;
     	box-sizing: border-box;


### PR DESCRIPTION
It's a bit tricky using media queries within `notifications-panel`, because when we run in the iframe, the document's width is different because it's limited to the width of the iframe.

This PR removes the media query we were using to show/hide the border to the left of the filter bar. It now shows properly in wide mode in both the iframe and calypso:

_iframe_
![iframe](https://user-images.githubusercontent.com/789137/26954760-d9dac3f0-4c66-11e7-83b2-9d554f6f6066.gif)

_calypso_
![calypso](https://user-images.githubusercontent.com/789137/26954768-e63c2b70-4c66-11e7-8bde-814bc4e6299c.gif)

There is one drawback, when on the small screen view you will have the border to the left. But to my eyes it is so small and hardly noticeable so I think it's a worthy trade off:
<img width="184" alt="screen shot 2017-06-08 at 4 19 39 pm" src="https://user-images.githubusercontent.com/789137/26954781-02e98d8a-4c67-11e7-80b9-a93d8ee0fc57.png">

**To test**
Run the client in the iframe and calypso. There should be a border to the left of the filter bar. When opening a note, the border should change to white.

Fixes #131 