### PR TITLE
Prettify our stylesheets.

### DIFF
--- a/bin/prettify-file.sh
+++ b/bin/prettify-file.sh
@@ -12,4 +12,4 @@ if [ ! -f ./node_modules/.bin/prettier ]; then
 	exit 1
 fi
 
-./node_modules/.bin/prettier --print-width=100 --single-quote --tab-width=4 --trailing-comma=es5 --write ${file}
+./node_modules/.bin/prettier --print-width=100 --single-quote --use-tabs --tab-width=4 --trailing-comma=es5 --write ${file}

--- a/bin/prettify-file.sh
+++ b/bin/prettify-file.sh
@@ -2,7 +2,7 @@
 
 file="$1"
 printf $file
-if [[ ! $file =~ ^(src|standalone)/[^\.]+\.jsx?$ ]]; then
+if [[ ! $file =~ ^(src|standalone)/[^\.]+\.(jsx?|scss)$ ]]; then
 	printf "\nNot a prettifiable file\n"
 	exit 0
 fi

--- a/bin/prettify-file.sh
+++ b/bin/prettify-file.sh
@@ -12,4 +12,4 @@ if [ ! -f ./node_modules/.bin/prettier ]; then
 	exit 1
 fi
 
-./node_modules/.bin/prettier --print-width=100 --single-quote --use-tabs --tab-width=4 --trailing-comma=es5 --write ${file}
+./node_modules/.bin/prettier --print-width=100 --single-quote --tab-width=4 --trailing-comma=es5 --write ${file}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mocha": "3.2.0",
     "mocha-jsdom": "1.1.0",
     "postcss-loader": "1.3.3",
-    "prettier": "1.2.2",
+    "prettier": "1.4.0",
     "sass-loader": "6.0.3",
     "style-loader": "0.16.0",
     "webpack-dev-server": "2.4.2"


### PR DESCRIPTION
Update Prettier to v1.4.0, to include prettifying our Sass stylesheets.

This keeps the existing `prettier` options the same; the affect on something like `main.scss` is everything being a space, with 4-space indents:

![screen shot 2017-06-14 at 1 30 19 pm](https://user-images.githubusercontent.com/349751/27153292-c3cb612a-5105-11e7-9c09-2b51c4b94769.png)

Tested with `main.scss` and `status-bar.jsx`, no apparent regressions. 