### PR TITLE
Fix responding to small screens when in iframe

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -796,11 +796,11 @@ body {
 
 		.wpnc__note-list {
 			left: auto;
-			width: 400px;
+			width: 410px;
 		}
 
     	.wpnc__single-view {
-    		right: 400px;
+    		right: 410px;
     		left: 10px;
     		top: 0px;
     		bottom: 0px;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -327,17 +327,12 @@ body {
       flex-direction: column;
       top: 0;
     	right: 0;
-    	left: auto;
+    	left: 0;
       bottom: 0;
-      width: 410px;
       overflow: hidden;
 			&:not(.is-note-open) {
 				box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
 			}
-
-      @media only screen and (max-width: 799px) {
-  			width: 100%;
-  		}
     }
 
     .wpnc__list-view {
@@ -346,7 +341,6 @@ body {
     	overflow-y: scroll;
     	-webkit-overflow-scrolling: touch;
     	border-left: 1px solid lighten( $gray, 30 );
-    	box-shadow: -3px 1px 10px -2px rgba($gray-dark, 0.075);
 
 			&.is-empty-list {
 				overflow-y: hidden;
@@ -800,8 +794,13 @@ body {
     		box-shadow: none;
     	}
 
+		.wpnc__note-list {
+			left: auto;
+			width: 400px;
+		}
+
     	.wpnc__single-view {
-    		right: 410px;
+    		right: 400px;
     		left: 10px;
     		top: 0px;
     		bottom: 0px;


### PR DESCRIPTION
There's a regression in the iframe version of `notificationsbeta` where notifications will not become full width on small screens. The fix was to not have a set width for the notes list until we reach a certain screen width.

Note: The spacing in `main.scss` hasn't been fixed up yet, so sorry for any weird spacing issues. See #152 

**To test**
* Run this branch on your sandbox: `./build-sandbox.sh -b -c fix/iframe-responsiveness`
* Open notifications on the front end of a sandboxed site
* Resize the browser window it should become full width at 480px or smaller.
* Also test the branch in calypso to ensure there aren't any regressions