### PR TITLE
Commit to two spaces for indenting.

### DIFF
--- a/bin/prettify-file.sh
+++ b/bin/prettify-file.sh
@@ -12,4 +12,4 @@ if [ ! -f ./node_modules/.bin/prettier ]; then
 	exit 1
 fi
 
-./node_modules/.bin/prettier --print-width=100 --single-quote --tab-width=4 --trailing-comma=es5 --write ${file}
+./node_modules/.bin/prettier --print-width=100 --single-quote --use-tabs --tab-width=4 --trailing-comma=es5 --write ${file}

--- a/bin/prettify-file.sh
+++ b/bin/prettify-file.sh
@@ -2,7 +2,7 @@
 
 file="$1"
 printf $file
-if [[ ! $file =~ ^(src|standalone)/[^\.]+\.jsx?$ ]]; then
+if [[ ! $file =~ ^(src|standalone)/[^\.]+\.(jsx?|scss)$ ]]; then
 	printf "\nNot a prettifiable file\n"
 	exit 0
 fi

--- a/bin/prettify-file.sh
+++ b/bin/prettify-file.sh
@@ -12,4 +12,4 @@ if [ ! -f ./node_modules/.bin/prettier ]; then
 	exit 1
 fi
 
-./node_modules/.bin/prettier --print-width=100 --single-quote --tab-width=4 --trailing-comma=es5 --write ${file}
+./node_modules/.bin/prettier --print-width=100 --single-quote --trailing-comma=es5 --write ${file}

--- a/bin/prettify-file.sh
+++ b/bin/prettify-file.sh
@@ -12,4 +12,4 @@ if [ ! -f ./node_modules/.bin/prettier ]; then
 	exit 1
 fi
 
-./node_modules/.bin/prettier --print-width=100 --single-quote --use-tabs --tab-width=4 --trailing-comma=es5 --write ${file}
+./node_modules/.bin/prettier --print-width=100 --single-quote --tab-width=4 --trailing-comma=es5 --write ${file}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mocha": "3.2.0",
     "mocha-jsdom": "1.1.0",
     "postcss-loader": "1.3.3",
-    "prettier": "1.2.2",
+    "prettier": "1.4.0",
     "sass-loader": "6.0.3",
     "style-loader": "0.16.0",
     "webpack-dev-server": "2.4.2"


### PR DESCRIPTION
Let's do it – let's commit the project to the Prettier default of two spaces for indenting (this PR relies on and includes #152). Let the reign of confusion be over.

Examples of `main.scss` and `status-bar.jsx`:

![screen shot 2017-06-14 at 1 36 00 pm](https://user-images.githubusercontent.com/349751/27153676-3b9016b4-5107-11e7-8968-3d5e738a368a.png)

![screen shot 2017-06-14 at 1 37 39 pm](https://user-images.githubusercontent.com/349751/27153680-4215bf48-5107-11e7-9793-76f5fa0a6944.png)

**Testing**
* Using this PR, run `./bin/prettify-file.sh "src/boot/stylesheets/main.scss"` (or any other stylesheet).
* Run `./bin/prettify-file.sh "src/templates/status-bar.jsx"` (or any other JSX file).
* Check that there are no visual regressions, and that indenting is done with two true spaces.