### PR TITLE
Update syntax in React classes to eliminate `React.createClass()`

### DIFF
--- a/src/templates/block-comment.jsx
+++ b/src/templates/block-comment.jsx
@@ -1,25 +1,17 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import { html } from '../indices-to-html';
 import { p } from './functions';
 
-export const CommentBlock = React.createClass({
-  render: function() {
-    var commentText = p(html(this.props.block));
-
-    var className = 'wpnc__comment';
-    if (this.props.meta.ids.comment != this.props.block.meta.ids.comment) {
-      className += ' comment-other';
-    } else {
-      className += ' comment-self';
-    }
-
-    return (
-      <div className={className}>
-        {commentText}
-      </div>
-    );
-  },
-});
+export const CommentBlock = ({ block, meta }) =>
+  <div
+    className={classNames('wpnc__comment', {
+      'comment-other': meta.ids.comment !== block.meta.ids.comment,
+      'comment-self': meta.ids.comment === block.meta.ids.comment,
+    })}
+  >
+    {p(html(block))}
+  </div>;
 
 export default CommentBlock;

--- a/src/templates/block-post.jsx
+++ b/src/templates/block-post.jsx
@@ -3,16 +3,9 @@ import React from 'react';
 import { html } from '../indices-to-html';
 import { p } from './functions';
 
-const PostBlock = React.createClass({
-  render: function() {
-    var postText = p(html(this.props.block));
-
-    return (
-      <div className="wpnc__post">
-        {postText}
-      </div>
-    );
-  },
-});
+const PostBlock = ({ block }) =>
+  <div className="wpnc__post">
+    {p(html(block))}
+  </div>;
 
 export default PostBlock;

--- a/src/templates/button-approve.jsx
+++ b/src/templates/button-approve.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,39 +12,33 @@ import ActionButton from './action-button';
 import { keys } from '../helpers/input';
 import { getReferenceId } from '../helpers/notes';
 
-const ApproveButton = React.createClass({
-  displayName: 'ApproveButton',
-
-  propTypes: {
-    isApproved: React.PropTypes.bool.isRequired,
-    note: React.PropTypes.object.isRequired,
-  },
-
-  render() {
-    const props = {
+const ApproveButton = ({ isApproved, note, translate }) =>
+  <ActionButton
+    {...{
       icon: 'checkmark',
-      isActive: this.props.isApproved,
+      isActive: isApproved,
       hotkey: keys.KEY_A,
       onToggle: () =>
         setApproveStatus(
-          this.props.note.id,
-          getReferenceId(this.props.note, 'site'),
-          getReferenceId(this.props.note, 'comment'),
-          !this.props.isApproved,
-          this.props.note.type
+          note.id,
+          getReferenceId(note, 'site'),
+          getReferenceId(note, 'comment'),
+          !isApproved,
+          note.type
         ),
-      text: this.props.isApproved
-        ? this.props.translate('Approved', { context: 'verb: past-tense' })
-        : this.props.translate('Approve', { context: 'verb: imperative' }),
-      title: this.props.isApproved
-        ? this.props.translate('Unapprove comment', {
-            context: 'verb: imperative',
-          })
-        : this.props.translate('Approve comment', { context: 'verb: imperative' }),
-    };
+      text: isApproved
+        ? translate('Approved', { context: 'verb: past-tense' })
+        : translate('Approve', { context: 'verb: imperative' }),
+      title: isApproved
+        ? translate('Unapprove comment', { context: 'verb: imperative' })
+        : translate('Approve comment', { context: 'verb: imperative' }),
+    }}
+  />;
 
-    return <ActionButton {...props} />;
-  },
-});
+ApproveButton.propTypes = {
+  isApproved: PropTypes.bool.isRequired,
+  note: PropTypes.object.isRequired,
+  translate: PropTypes.func.isRequired,
+};
 
 export default localize(ApproveButton);

--- a/src/templates/button-like.jsx
+++ b/src/templates/button-like.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,43 +12,36 @@ import ActionButton from './action-button';
 import { keys } from '../helpers/input';
 import { getReferenceId } from '../helpers/notes';
 
-const LikeButton = React.createClass({
-  displayName: 'LikeButton',
-
-  propTypes: {
-    commentId: React.PropTypes.number,
-    note: React.PropTypes.object.isRequired,
-  },
-
-  render() {
-    const props = {
+const LikeButton = ({ commentId, isLiked, note, translate }) =>
+  <ActionButton
+    {...{
       icon: 'star',
-      isActive: this.props.isLiked,
+      isActive: isLiked,
       hotkey: keys.KEY_L,
       onToggle: () =>
         setLikeStatus(
-          this.props.note.id,
-          getReferenceId(this.props.note, 'site'),
-          getReferenceId(this.props.note, 'post'),
-          getReferenceId(this.props.note, 'comment'),
-          !this.props.isLiked
+          note.id,
+          getReferenceId(note, 'site'),
+          getReferenceId(note, 'post'),
+          getReferenceId(note, 'comment'),
+          !isLiked
         ),
-      text: this.props.isLiked
-        ? this.props.translate('Liked', { context: 'verb: past-tense' })
-        : this.props.translate('Like', { context: 'verb: imperative' }),
-      title: this.props.isLiked
-        ? this.props.commentId
-          ? this.props.translate('Remove like from comment')
-          : this.props.translate('Remove like from post')
-        : this.props.commentId
-          ? this.props.translate('Like comment', {
-              context: 'verb: imperative',
-            })
-          : this.props.translate('Like post', { context: 'verb: imperative' }),
-    };
+      text: isLiked
+        ? translate('Liked', { context: 'verb: past-tense' })
+        : translate('Like', { context: 'verb: imperative' }),
+      title: isLiked
+        ? commentId ? translate('Remove like from comment') : translate('Remove like from post')
+        : commentId
+          ? translate('Like comment', { context: 'verb: imperative' })
+          : translate('Like post', { context: 'verb: imperative' }),
+    }}
+  />;
 
-    return <ActionButton {...props} />;
-  },
-});
+LikeButton.propTypes = {
+  commentId: PropTypes.number,
+  isLiked: PropTypes.bool.isRequired,
+  note: PropTypes.object.isRequired,
+  translate: PropTypes.func.isRequired,
+};
 
 export default localize(LikeButton);

--- a/src/templates/button-spam.jsx
+++ b/src/templates/button-spam.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,27 +11,21 @@ import { spamNote } from '../flux/note-actions';
 import ActionButton from './action-button';
 import { keys } from '../helpers/input';
 
-const SpamButton = React.createClass({
-  displayName: 'TrashButton',
-
-  propTypes: {
-    note: React.PropTypes.object.isRequired,
-  },
-
-  render() {
-    const props = {
+const SpamButton = ({ note, translate }) =>
+  <ActionButton
+    {...{
       icon: 'spam',
       isActive: false,
       hotkey: keys.KEY_S,
-      onToggle: () => spamNote(this.props.note),
-      text: this.props.translate('Spam', { context: 'verb: Mark as Spam' }),
-      title: this.props.translate('Mark comment as spam', {
-        context: 'verb: imperative',
-      }),
-    };
+      onToggle: () => spamNote(note),
+      text: translate('Spam', { context: 'verb: Mark as Spam' }),
+      title: translate('Mark comment as spam', { context: 'verb: imperative' }),
+    }}
+  />;
 
-    return <ActionButton {...props} />;
-  },
-});
+SpamButton.propTypes = {
+  note: PropTypes.object.isRequired,
+  translate: PropTypes.func.isRequired,
+};
 
 export default localize(SpamButton);

--- a/src/templates/button-trash.jsx
+++ b/src/templates/button-trash.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,25 +11,21 @@ import { trashNote } from '../flux/note-actions';
 import ActionButton from './action-button';
 import { keys } from '../helpers/input';
 
-const TrashButton = React.createClass({
-  displayName: 'TrashButton',
-
-  propTypes: {
-    note: React.PropTypes.object.isRequired,
-  },
-
-  render() {
-    const props = {
+const TrashButton = ({ note, translate }) =>
+  <ActionButton
+    {...{
       icon: 'trash',
       isActive: false,
       hotkey: keys.KEY_T,
-      onToggle: () => trashNote(this.props.note),
-      text: this.props.translate('Trash', { context: 'verb: imperative' }),
-      title: this.props.translate('Trash comment', { context: 'verb: imperative' }),
-    };
+      onToggle: () => trashNote(note),
+      text: translate('Trash', { context: 'verb: imperative' }),
+      title: translate('Trash comment', { context: 'verb: imperative' }),
+    }}
+  />;
 
-    return <ActionButton {...props} />;
-  },
-});
+TrashButton.propTypes = {
+  note: PropTypes.object.isRequired,
+  translate: PropTypes.func.isRequired,
+};
 
 export default localize(TrashButton);

--- a/src/templates/error.jsx
+++ b/src/templates/error.jsx
@@ -1,14 +1,8 @@
 import React from 'react';
 
-export const Error = React.createClass({
-  render: function() {
-    console.log(this.props);
-    return (
-      <div className="error">
-        {this.props.error}
-      </div>
-    );
-  },
-});
+export const Error = ({ error }) =>
+  <div className="error">
+    {error}
+  </div>;
 
 export default Error;


### PR DESCRIPTION
Resolves part of #154 

Should only be styling updates