### PR TITLE
Fix: Notes not loading

### DIFF
--- a/src/Notifications.jsx
+++ b/src/Notifications.jsx
@@ -61,7 +61,19 @@ export class Notifications extends PureComponent {
     initStore({
       customEnhancer,
       customMiddleware: mergeHandlers(customMiddleware, {
-        APP_REFRESH_NOTES: [() => client && client.refreshNotes.call(client)],
+        APP_REFRESH_NOTES: [
+          (store, action) => {
+            if (!client) {
+              return;
+            }
+
+            if ('boolean' === typeof action.isVisible) {
+              client.setVisibility.call(client, { isShowing, isVisible: action.isVisible });
+            }
+
+            client.refreshNotes.call(client, action.isVisible);
+          },
+        ],
       }),
     });
 

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -17,74 +17,74 @@ let store = { dispatch: () => {}, getState: () => {} };
 const customEnhancer = next => (reducer, initialState) => (store = next(reducer, initialState));
 
 const customMiddleware = {
-    APP_IS_READY: [() => sendMessage({ action: 'iFrameReady' })],
-    APP_RENDER_NOTES: [
-        (store, { latestType, newNoteCount }) =>
-            (newNoteCount > 0
-                ? sendMessage({ action: 'render', num_new: newNoteCount, latest_type: latestType })
-                : sendMessage({ action: 'renderAllSeen' })),
-    ],
-    CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
-    OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
-    OPEN_POST: [(store, { siteId, postId, href }) => window.open(href, '_blank')],
-    SET_LAYOUT: [
-        (store, { layout }) =>
-            sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),
-    ],
-    VIEW_SETTINGS: [() => window.open('https://wordpress.com/me/notifications')],
+  APP_IS_READY: [() => sendMessage({ action: 'iFrameReady' })],
+  APP_RENDER_NOTES: [
+    (store, { latestType, newNoteCount }) =>
+      newNoteCount > 0
+        ? sendMessage({ action: 'render', num_new: newNoteCount, latest_type: latestType })
+        : sendMessage({ action: 'renderAllSeen' }),
+  ],
+  CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
+  OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
+  OPEN_POST: [(store, { siteId, postId, href }) => window.open(href, '_blank')],
+  SET_LAYOUT: [
+    (store, { layout }) =>
+      sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),
+  ],
+  VIEW_SETTINGS: [() => window.open('https://wordpress.com/me/notifications')],
 };
 
 const render = () => {
-    ReactDOM.render(
-        React.createElement(AuthWrapper(Notifications), {
-            clientId: 52716,
-            customEnhancer,
-            customMiddleware,
-            isShowing,
-            isVisible,
-            locale,
-            receiveMessage: sendMessage,
-            redirectPath: '/',
-        }),
-        document.getElementsByClassName('wpnc__main')[0]
-    );
+  ReactDOM.render(
+    React.createElement(AuthWrapper(Notifications), {
+      clientId: 52716,
+      customEnhancer,
+      customMiddleware,
+      isShowing,
+      isVisible,
+      locale,
+      receiveMessage: sendMessage,
+      redirectPath: '/',
+    }),
+    document.getElementsByClassName('wpnc__main')[0]
+  );
 };
 
 const init = () => {
-    render();
+  render();
 
-    const refresh = () => store.dispatch({ type: 'APP_REFRESH_NOTES' });
-    const reset = () => store.dispatch({ type: 'SELECT_NOTE', noteId: null });
+  const refresh = () => store.dispatch({ type: 'APP_REFRESH_NOTES', isVisible });
+  const reset = () => store.dispatch({ type: 'SELECT_NOTE', noteId: null });
 
-    document.addEventListener('visibilitychange', refresh);
+  document.addEventListener('visibilitychange', refresh);
 
-    window.addEventListener(
-        'message',
-        receiveMessage(({ action, hidden, showing }) => {
-            if ('togglePanel' === action) {
-                if (isShowing && !showing) {
-                    reset();
-                }
+  window.addEventListener(
+    'message',
+    receiveMessage(({ action, hidden, showing }) => {
+      if ('togglePanel' === action) {
+        if (isShowing && !showing) {
+          reset();
+        }
 
-                isShowing = showing;
-                refresh();
-            }
+        isShowing = showing;
+        refresh();
+      }
 
-            if ('toggleVisibility' === action) {
-                isVisible = !hidden;
-                refresh();
-            }
-        })
-    );
+      if ('toggleVisibility' === action) {
+        isVisible = !hidden;
+        refresh();
+      }
+    })
+  );
 
-    window.addEventListener(
-        'message',
-        receiveMessage(({ action }) => {
-            if ('refreshNotes' === action) {
-                refreshNotes();
-            }
-        })
-    );
+  window.addEventListener(
+    'message',
+    receiveMessage(({ action }) => {
+      if ('refreshNotes' === action) {
+        refreshNotes();
+      }
+    })
+  );
 };
 
 init();


### PR DESCRIPTION
Resolves #162 

It appears that when loading the notifications panel in a window that is originally `hidden` then the notes core never realizes that it has become visible. Thus, when we open it it's still not polling for the notifications data.

Now we are passing along current visibility information in the standalone client when changing window visibility. The `rest-client` then updates its own state based on this value.

**Testing**
Load the notifications panel when hidden. Reload a browser tab and switch to another tab, for instance. In **master** it should not load notes but in this branch it should when you switch back to the tab.