### PR TITLE
React: refactor usage of React.createClass()

### DIFF
--- a/src/templates/container-hotkey.jsx
+++ b/src/templates/container-hotkey.jsx
@@ -1,40 +1,40 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
  */
 import { modifierKeyIsActive, shortcutsAreEnabled } from '../helpers/input';
 
-const HotkeyContainer = React.createClass({
-  propTypes: {
-    shortcuts: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        action: React.PropTypes.func.isRequired,
-        hotkey: React.PropTypes.number.isRequired,
-        withModifiers: React.PropTypes.bool,
+const dispatch = (event, action) => {
+  event.preventDefault();
+  event.stopPropagation();
+
+  action();
+};
+
+export class HotkeyContainer extends Component {
+  static propTypes = {
+    shortcuts: PropTypes.arrayOf(
+      PropTypes.shape({
+        action: PropTypes.func.isRequired,
+        hotkey: PropTypes.number.isRequired,
+        withModifiers: PropTypes.bool,
       })
     ),
-  },
+  };
 
   componentDidMount() {
     window.addEventListener('keydown', this.handleKeyDown, false);
-  },
+  }
 
   componentWillUnmount() {
     window.removeEventListener('keydown', this.handleKeyDown, false);
-  },
+  }
 
-  dispatch(event, action) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    action();
-  },
-
-  handleKeyDown(event) {
+  handleKeyDown = event => {
     if (!this.props.shortcuts || !shortcutsAreEnabled()) {
       return;
     }
@@ -42,12 +42,12 @@ const HotkeyContainer = React.createClass({
     this.props.shortcuts
       .filter(shortcut => shortcut.hotkey === event.keyCode)
       .filter(shortcut => (shortcut.withModifiers || false) === modifierKeyIsActive(event))
-      .forEach(shortcut => this.dispatch(event, shortcut.action));
-  },
+      .forEach(shortcut => dispatch(event, shortcut.action));
+  };
 
   render() {
     return this.props.children;
-  },
-});
+  }
+}
 
 export default HotkeyContainer;

--- a/src/templates/empty-message.jsx
+++ b/src/templates/empty-message.jsx
@@ -1,64 +1,53 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 import { bumpStat } from '../rest-client/bump-stat';
 
 // from $title-offset in boot/sizes.scss
-var TITLE_OFFSET = 38;
+const TITLE_OFFSET = 38;
 
-export const EmptyMessage = React.createClass({
-  componentWillMount: function() {
+export class EmptyMessage extends Component {
+  componentWillMount() {
     if (this.props.showing) {
       bumpStat('notes-empty-message', this.props.name + '_shown');
     }
-  },
+  }
 
-  componentDidUpdate: function() {
+  componentDidUpdate() {
     if (this.props.showing) {
       bumpStat('notes-empty-message', this.props.name + '_shown');
     }
-  },
+  }
 
-  handleClick: function() {
-    bumpStat('notes-empty-message', this.props.name + '_clicked');
-  },
+  handleClick = () => bumpStat('notes-empty-message', this.props.name + '_clicked');
 
-  render: function() {
-    var message;
-    if (this.props.link && this.props.linkMessage) {
-      message = (
-        <div className="wpnc__empty-notes">
-          <h2>{this.props.emptyMessage}</h2>
-          <p>
-            <a href={this.props.link} target="_blank" onClick={this.handleClick}>
-              {this.props.linkMessage}
-            </a>
-          </p>
-        </div>
-      );
-    } else if (this.props.linkMessage) {
-      message = (
-        <div className="wpnc__empty-notes">
-          <h2>{this.props.emptyMessage}</h2>
-          <p>{this.props.linkMessage}</p>
-        </div>
-      );
-    } else {
-      message = (
-        <div className="wpnc__empty-notes">
-          <h2>{this.props.emptyMessage}</h2>
-        </div>
-      );
-    }
+  render() {
+    const { emptyMessage, link, linkMessage } = this.props;
 
     return (
       <div
         className="wpnc__empty-notes-container"
         style={{ height: this.props.height - TITLE_OFFSET + 'px' }}
       >
-        {message}
+        {link &&
+          linkMessage &&
+          <div className="wpnc__empty-notes">
+            <h2>{emptyMessage}</h2>
+            <p><a href={link} target="_blank" onClick={this.handleClick}>{linkMessage}</a></p>
+          </div>}
+        {!link &&
+          linkMessage &&
+          <div className="wpnc__empty-notes">
+            <h2>{emptyMessage}</h2>
+            <p>{linkMessage}</p>
+          </div>}
+        {!link &&
+          !linkMessage &&
+          <div className="wpnc__empty-notes">
+            <h2>{emptyMessage}</h2>
+          </div>}
       </div>
     );
-  },
-});
+  }
+}
 
 export default EmptyMessage;

--- a/src/templates/filter-bar.jsx
+++ b/src/templates/filter-bar.jsx
@@ -1,14 +1,12 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 
 import Filters from './filters';
 import getFilterName from '../state/selectors/get-filter-name';
 
-var debug = require('debug')('notifications:filterbar');
-var classnames = require('classnames');
-
-export const FilterBar = React.createClass({
-  selectFilter(event) {
+export class FilterBar extends Component {
+  selectFilter = event => {
     if (event) {
       event.stopPropagation();
       event.preventDefault();
@@ -16,52 +14,35 @@ export const FilterBar = React.createClass({
 
     const filterName = event.target.dataset.filterName;
     this.props.controller.selectFilter(filterName);
-  },
+  };
 
-  render: function() {
-    var filterItems = [];
+  render() {
+    const { filterName } = this.props;
 
-    if (this.props.current) {
-      return null;
-    }
-
-    for (var filterName in Filters) {
-      if (!Filters.hasOwnProperty(filterName)) {
-        continue;
-      }
-      filterItems.push(Filters[filterName]());
-    }
-
-    filterItems.sort(function(a, b) {
-      return a.index - b.index;
-    });
-
-    filterItems = filterItems.map(function(filter) {
-      const classes = classnames('wpnc__filter__segmented-control-item', {
-        selected: filter.name === this.props.filterName,
-      });
-
-      return (
-        <li
-          key={filter.name}
-          data-filter-name={filter.name}
-          className={classes}
-          onClick={this.selectFilter}
-        >
-          {filter.label}
-        </li>
-      );
-    }, this);
+    const filterItems = Object.keys(Filters)
+      .map(name => Filters[name]())
+      .sort((a, b) => a.index - b.index);
 
     return (
       <div className="wpnc__filter">
         <ul className="wpnc__filter__segmented-control">
-          {filterItems}
+          {filterItems.map(({ label, name }) =>
+            <li
+              key={name}
+              data-filter-name={name}
+              className={classNames('wpnc__filter__segmented-control-item', {
+                selected: name === filterName,
+              })}
+              onClick={this.selectFilter}
+            >
+              {label}
+            </li>
+          )}
         </ul>
       </div>
     );
-  },
-});
+  }
+}
 
 const mapStateToProps = state => ({
   filterName: getFilterName(state),

--- a/src/templates/image-loader.jsx
+++ b/src/templates/image-loader.jsx
@@ -1,48 +1,46 @@
 /**
  * External dependencies
  */
-var React = require('react');
+import React, { Component, PropTypes } from 'react';
+import { noop } from 'lodash';
 
 /**
  * Module variables
  */
-var LoadStatus = {
+const LoadStatus = {
   PENDING: 'PENDING',
   LOADING: 'LOADING',
   LOADED: 'LOADED',
   FAILED: 'FAILED',
-},
-  noop = function() {};
+};
 
-export const ImageLoader = React.createClass({
-  propTypes: {
-    src: React.PropTypes.string.isRequired,
-    placeholder: React.PropTypes.element.isRequired,
-    children: React.PropTypes.node,
-  },
+export class ImageLoader extends Component {
+  static propTypes = {
+    src: PropTypes.string.isRequired,
+    placeholder: PropTypes.element.isRequired,
+    children: PropTypes.node,
+  };
 
-  getInitialState: function() {
-    return {
-      status: LoadStatus.PENDING,
-    };
-  },
+  state = {
+    status: LoadStatus.PENDING,
+  };
 
-  componentWillMount: function() {
+  componentWillMount() {
     this.createLoader();
-  },
+  }
 
-  componentWillReceiveProps: function(nextProps) {
+  componentWillReceiveProps(nextProps) {
     if (nextProps.src !== this.props.src) {
       this.createLoader(nextProps);
     }
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     this.destroyLoader();
-  },
+  }
 
-  createLoader: function(nextProps) {
-    var src = (nextProps || this.props).src;
+  createLoader = nextProps => {
+    const src = (nextProps || this.props).src;
 
     this.destroyLoader();
 
@@ -54,9 +52,9 @@ export const ImageLoader = React.createClass({
     this.setState({
       status: LoadStatus.LOADING,
     });
-  },
+  };
 
-  destroyLoader: function() {
+  destroyLoader = () => {
     if (!this.image) {
       return;
     }
@@ -64,42 +62,28 @@ export const ImageLoader = React.createClass({
     this.image.onload = noop;
     this.image.onerror = noop;
     delete this.image;
-  },
+  };
 
-  onLoadComplete: function(event) {
+  onLoadComplete = event => {
     this.destroyLoader();
 
     this.setState({
       status: 'load' === event.type ? LoadStatus.LOADED : LoadStatus.FAILED,
     });
-  },
+  };
 
-  render: function() {
-    var children, imageProps;
-
-    switch (this.state.status) {
-      case LoadStatus.LOADING:
-        children = this.props.placeholder;
-        break;
-
-      case LoadStatus.LOADED:
-        children = <img src={this.props.src} />;
-        break;
-
-      case LoadStatus.FAILED:
-        children = this.props.children;
-        break;
-
-      default:
-        break;
-    }
+  render() {
+    const { children, placeholder, src } = this.props;
+    const { status } = this.state;
 
     return (
       <div className="image-preloader">
-        {children}
+        {status === LoadStatus.LOADING && placeholder}
+        {status === LoadStatus.LOADED && <img src={src} />}
+        {status === LoadStatus.FAILED && children}
       </div>
     );
-  },
-});
+  }
+}
 
 export default ImageLoader;

--- a/src/templates/nav-button.jsx
+++ b/src/templates/nav-button.jsx
@@ -3,40 +3,41 @@
  */
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Gridicon from './gridicons';
 
-export const NavButton = React.createClass({
-  navigate(event) {
+export class NavButton extends Component {
+  static propTypes = {
+    iconName: PropTypes.string.isRequired,
+    className: PropTypes.string,
+    isEnabled: PropTypes.bool.isRequired,
+    navigate: PropTypes.func.isRequired,
+  };
+
+  navigate = event => {
     event.stopPropagation();
     event.preventDefault();
 
     this.props.navigate();
-  },
+  };
 
   render() {
+    const { className, iconName, isEnabled } = this.props;
+
     return (
       <button
-        className={classNames(this.props.className, {
-          disabled: !this.props.isEnabled,
-        })}
-        disabled={!this.props.isEnabled}
-        onClick={this.props.isEnabled ? this.navigate : null}
+        className={classNames(className, { disabled: !isEnabled })}
+        disabled={!isEnabled}
+        onClick={isEnabled ? this.navigate : noop}
       >
-        <Gridicon icon={this.props.iconName} size={18} />
+        <Gridicon icon={iconName} size={18} />
       </button>
     );
-  },
-});
-
-NavButton.propTypes = {
-  iconName: PropTypes.string.isRequired,
-  className: PropTypes.string,
-  isEnabled: PropTypes.bool.isRequired,
-  navigate: PropTypes.func.isRequired,
-};
+  }
+}
 
 export default NavButton;

--- a/src/templates/preface.jsx
+++ b/src/templates/preface.jsx
@@ -2,15 +2,9 @@ import React from 'react';
 
 import { pSoup } from './functions';
 
-export const Preface = React.createClass({
-  render: function() {
-    var ps = pSoup(this.props.blocks);
-    return (
-      <div className="wpnc__preface">
-        {ps}
-      </div>
-    );
-  },
-});
+export const Preface = ({ blocks }) =>
+  <div className="wpnc__preface">
+    {pSoup(blocks)}
+  </div>;
 
 export default Preface;


### PR DESCRIPTION
More work in #154 

**Testing**

As usual, just test with `npm start`. Any breakage should be obvious via errors or malformed UI.
There are no functional changes in this PR: only syntax.

Pay attention to the filter bar where I have actually refactored some logic to remove the `var` reassignment.

cc: @Automattic/lannister 