### PR TITLE
Support for OPEN_COMMENT middleware action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.1.19",
+  "version": "1.2.0",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/src/templates/block-user.jsx
+++ b/src/templates/block-user.jsx
@@ -87,7 +87,7 @@ export const UserBlock = React.createClass({
 
       timeIndicator = (
         <span className="wpnc__user__timeIndicator">
-          <a href={this.props.note.url} target="_blank" {...linkProps( this.props.note )} >
+          <a href={this.props.note.url} target="_blank" {...linkProps(this.props.note)}>
             {this.getTimeString(this.props.note.timestamp)}
           </a>
           <span className="wpnc__user__bullet" />

--- a/src/templates/block-user.jsx
+++ b/src/templates/block-user.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 import getIsNoteApproved from '../state/selectors/get-is-note-approved';
+import { linkProps } from './functions';
 
 import FollowLink from './follow-link';
 
@@ -86,7 +87,7 @@ export const UserBlock = React.createClass({
 
       timeIndicator = (
         <span className="wpnc__user__timeIndicator">
-          <a href={this.props.note.url} target="_blank">
+          <a href={this.props.note.url} target="_blank" {...linkProps( this.props.note )} >
             {this.getTimeString(this.props.note.timestamp)}
           </a>
           <span className="wpnc__user__bullet" />

--- a/src/templates/functions.jsx
+++ b/src/templates/functions.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { html as toHtml } from '../indices-to-html';
+import { pickBy } from 'lodash';
 
 /**
  * Adds markup to some common text patterns
@@ -230,3 +231,27 @@ export function zipWithSignature(blocks, note) {
 }
 
 export const validURL = /^(?:http(?:s?)\:\/\/|~\/|\/)?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|blog|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?$/i;
+
+export const linkProps = note => {
+  const { site, comment, post } = note.meta.ids;
+  let type;
+
+  if ( comment ) {
+    type = 'comment';
+  } else if ( post ) {
+    type = 'post';
+  }
+
+  switch (type) {
+    case 'post':
+    case 'comment':
+      return pickBy( {
+        'data-link-type': type,
+        'data-site-id': site,
+        'data-post-id': post,
+        'data-comment-id': comment,
+      } );
+    default:
+      return {};
+  }
+};

--- a/src/templates/functions.jsx
+++ b/src/templates/functions.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { html as toHtml } from '../indices-to-html';
-import { pickBy } from 'lodash';
+import { pickBy, get } from 'lodash';
 
 /**
  * Adds markup to some common text patterns
@@ -233,7 +233,7 @@ export function zipWithSignature(blocks, note) {
 export const validURL = /^(?:http(?:s?)\:\/\/|~\/|\/)?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|blog|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?$/i;
 
 export const linkProps = note => {
-  const { site, comment, post } = get( note, 'meta.ids', {} );
+  const { site, comment, post } = get(note, 'meta.ids', {});
   let type;
 
   if (comment) {

--- a/src/templates/functions.jsx
+++ b/src/templates/functions.jsx
@@ -236,21 +236,21 @@ export const linkProps = note => {
   const { site, comment, post } = note.meta.ids;
   let type;
 
-  if ( comment ) {
+  if (comment) {
     type = 'comment';
-  } else if ( post ) {
+  } else if (post) {
     type = 'post';
   }
 
   switch (type) {
     case 'post':
     case 'comment':
-      return pickBy( {
+      return pickBy({
         'data-link-type': type,
         'data-site-id': site,
         'data-post-id': post,
         'data-comment-id': comment,
-      } );
+      });
     default:
       return {};
   }

--- a/src/templates/functions.jsx
+++ b/src/templates/functions.jsx
@@ -233,7 +233,7 @@ export function zipWithSignature(blocks, note) {
 export const validURL = /^(?:http(?:s?)\:\/\/|~\/|\/)?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|blog|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?$/i;
 
 export const linkProps = note => {
-  const { site, comment, post } = note.meta.ids;
+  const { site, comment, post } = get( note, 'meta.ids', {} );
   let type;
 
   if (comment) {

--- a/src/templates/summary-in-single.jsx
+++ b/src/templates/summary-in-single.jsx
@@ -1,46 +1,7 @@
 import React from 'react';
 
 import { html } from '../indices-to-html';
-
-const getPostRef = note => {
-  const { header = [] } = note;
-  const hRanges = header.map(({ ranges = [] }) => ranges).reduce((a, b) => [...a, ...b], []);
-  const hPosts = hRanges.filter(({ type }) => 'post' === type);
-
-  if (hPosts.length === 1) {
-    return hPosts[0];
-  }
-
-  const { subject = [] } = note;
-  const sRanges = subject.map(({ ranges = [] }) => ranges).reduce((a, b) => [...a, ...b], []);
-  const sPosts = sRanges.filter(({ type }) => 'post' === type);
-
-  if (sPosts.length === 1) {
-    return sPosts[0];
-  }
-
-  return null;
-};
-
-const linkProps = note => {
-  const post = getPostRef(note);
-  if (!post) {
-    return {};
-  }
-
-  const { id, site_id, type } = post;
-
-  switch (type) {
-    case 'post':
-      return {
-        'data-link-type': type,
-        'data-site-id': site_id,
-        'data-post-id': id,
-      };
-    default:
-      return {};
-  }
-};
+import { linkProps } from './functions';
 
 const Snippet = ({ note, snippet, url }) =>
   <a href={url} {...linkProps(note)} target="_blank">

--- a/src/utils/link-interceptor.js
+++ b/src/utils/link-interceptor.js
@@ -2,7 +2,13 @@ import { store } from '../state';
 
 const openLink = href => ({ type: 'OPEN_LINK', href });
 const openPost = (siteId, postId, href) => ({ type: 'OPEN_POST', siteId, postId, href });
-const openComment = ( { siteId, postId, href, commentId } ) => ( { type: 'OPEN_COMMENT', siteId, postId, href, commentId  } );
+const openComment = ({ siteId, postId, href, commentId }) => ({
+  type: 'OPEN_COMMENT',
+  siteId,
+  postId,
+  href,
+  commentId,
+});
 
 export const interceptLinks = event => {
   const { target } = event;
@@ -24,8 +30,8 @@ export const interceptLinks = event => {
 
   if ('post' === linkType) {
     store.dispatch(openPost(siteId, postId, href));
-  } else if( 'comment' === linkType ) {
-    store.dispatch(openComment({ siteId, postId, href, commentId }))
+  } else if ('comment' === linkType) {
+    store.dispatch(openComment({ siteId, postId, href, commentId }));
   } else {
     store.dispatch(openLink(href));
   }

--- a/src/utils/link-interceptor.js
+++ b/src/utils/link-interceptor.js
@@ -2,6 +2,7 @@ import { store } from '../state';
 
 const openLink = href => ({ type: 'OPEN_LINK', href });
 const openPost = (siteId, postId, href) => ({ type: 'OPEN_POST', siteId, postId, href });
+const openComment = ( { siteId, postId, href, commentId } ) => ( { type: 'OPEN_COMMENT', siteId, postId, href, commentId  } );
 
 export const interceptLinks = event => {
   const { target } = event;
@@ -12,7 +13,7 @@ export const interceptLinks = event => {
 
   const node = 'A' === target.tagName ? target : target.parentNode;
   const { dataset = {}, href } = node;
-  const { linkType, postId, siteId } = dataset;
+  const { linkType, postId, siteId, commentId } = dataset;
 
   if (!linkType) {
     return true;
@@ -23,6 +24,8 @@ export const interceptLinks = event => {
 
   if ('post' === linkType) {
     store.dispatch(openPost(siteId, postId, href));
+  } else if( 'comment' === linkType ) {
+    store.dispatch(openComment({ siteId, postId, href, commentId }))
   } else {
     store.dispatch(openLink(href));
   }

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -26,7 +26,8 @@ const customMiddleware = {
   ],
   CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
   OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
-  OPEN_POST: [(store, { siteId, postId, href }) => window.open(href, '_blank')],
+  OPEN_POST: [(store, { href }) => window.open(href, '_blank')],
+  OPEN_COMMENT: [(store, { href }) => window.open(href, '_blank')],
   SET_LAYOUT: [
     (store, { layout }) =>
       sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),


### PR DESCRIPTION
In order to support opening directly to comments within Calypso, the notifications-panel needs to support dispatching a new action for opening comments instead of just one for opening posts.

On top of that, we also need to start dispatching actions when timestamps are clicked.

This PR seeks to address both points.