### PR TITLE
Links: open in new tab if meta/ctrl are pressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/src/utils/link-interceptor.js
+++ b/src/utils/link-interceptor.js
@@ -25,6 +25,12 @@ export const interceptLinks = event => {
     return true;
   }
 
+  const newTab = event.ctrlKey || event.metaKey;
+  if (newTab) {
+    window.open(href, '_blank');
+    return true;
+  }
+
   event.stopPropagation();
   event.preventDefault();
 

--- a/src/utils/link-interceptor.js
+++ b/src/utils/link-interceptor.js
@@ -27,8 +27,7 @@ export const interceptLinks = event => {
 
   const newTab = event.ctrlKey || event.metaKey;
   if (newTab) {
-    window.open(href, '_blank');
-    return true;
+    return true; // will open in new tab b/c we dont eat the event
   }
 
   event.stopPropagation();

--- a/src/utils/link-interceptor.js
+++ b/src/utils/link-interceptor.js
@@ -25,9 +25,12 @@ export const interceptLinks = event => {
     return true;
   }
 
-  const newTab = event.ctrlKey || event.metaKey;
-  if (newTab) {
-    return true; // will open in new tab b/c we dont eat the event
+  // we don't want to interfere with the click
+  // if the user has specifically overwritten the
+  // normal behavior already by holding down
+  // one of the modifier keys.
+  if (event.ctrlKey || event.metaKey) {
+    return true;
   }
 
   event.stopPropagation();


### PR DESCRIPTION
~~For now this should have no functional changes.~~

~~It adds the property `newTab` to the OPEN_POST / OPEN_LINK actions.  newTab true/false is determined by if ctrl/meta are on the event object.~~

On the suggestion of @dmsnell, this ignores sending anything to the middleware and opens links in a new tab when cmd/ctrl are held during the notification click.


mdn source for mouse events: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent


To test:
In the calypso directory run: `npm install 'Automattic/notifications-panel#fix/cmdclick-open-new-tab'`
then make run as usual and verify cmd/ctrl clicks are working as expected