### PR TITLE
package.json: Change main to esnext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "2.0.0",
+  "version": "1.3.0",
   "description": "The core notifications panel for WordPress.com notifications",
   "esnext": "src/Notifications.jsx",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notifications-panel",
   "version": "1.2.7",
   "description": "The core notifications panel for WordPress.com notifications",
-  "main": "src/Notifications.jsx",
+  "esnext": "src/Notifications.jsx",
   "scripts": {
     "build": "webpack",
     "build:prod": "NODE_ENV=production webpack -p",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.2.7",
+  "version": "2.0.0",
   "description": "The core notifications panel for WordPress.com notifications",
   "esnext": "src/Notifications.jsx",
   "scripts": {


### PR DESCRIPTION
To better denote we're dealing with untranspiled code.

Companion Calypso PR: https://github.com/Automattic/wp-calypso/pull/16870

To provide a bit of an explanation -- `esnext` is a custom field.
* We'll specify it as a possible entry point for webpack to watch out for [here](https://github.com/Automattic/wp-calypso/pull/16870/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dR141).
* OTOH, we use it (as opposed to `main`) as a flag to indicate that this is a package's entrypoint for untranspiled code [here](https://github.com/Automattic/wp-calypso/pull/16870/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dR108).

This is a strategy found at http://2ality.com/2017/06/pkg-esnext.html.

Suggested order:
* Merge this
* Release new version
* Calypso: Include `notifications-panel` version bump with https://github.com/Automattic/wp-calypso/pull/16870
* Test https://github.com/Automattic/wp-calypso/pull/16870
* Merge https://github.com/Automattic/wp-calypso/pull/16870