### PR TITLE
i18n: Fix display of English text in the filter bar

### DIFF
--- a/src/templates/filter-bar.jsx
+++ b/src/templates/filter-bar.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 import Filters from './filters';
 import getFilterName from '../state/selectors/get-filter-name';
@@ -48,4 +49,4 @@ const mapStateToProps = state => ({
   filterName: getFilterName(state),
 });
 
-export default connect(mapStateToProps)(FilterBar);
+export default connect(mapStateToProps)(localize( FilterBar ));


### PR DESCRIPTION
Fixes #173. The component wasn't started localized.

Old behavior:
![notifications-translation](https://user-images.githubusercontent.com/203408/28924932-a435d090-7863-11e7-839b-55921c71095e.gif)

New behavior: No change of UI language.