### PR TITLE
Build: Use long `git` description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "The core notifications panel for WordPress.com notifications",
   "main": "src/Notifications.jsx",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = {
 		} ),
 		new HtmlWebpackPlugin( {
 			filename: 'root.html',
-			gitDescribe: spawnSync( 'git', [ 'describe', '--always', '--dirty' ] ).stdout.toString( 'utf8' ).replace( '\n', '' ),
+			gitDescribe: spawnSync( 'git', [ 'describe', '--always', '--dirty', '--long' ], { encoding: 'utf8' } ).stdout.replace( '\n', '' ),
 			hash: true,
 			nodePlatform: process.platform,
 			nodeVersion: process.version,


### PR DESCRIPTION
When a commit hangs exactly at a tag `git describe --always --dirty`
will return just the tag and not the commit hash. This update makes sure
that we always include a commit hash in the output.

**Testing**

Just build it and look at `index.html` - I did and it looks right.