### PR TITLE
Standalone Panel: Add Tracks to custom middleware

### DIFF
--- a/standalone/index.js
+++ b/standalone/index.js
@@ -26,16 +26,16 @@ const customMiddleware = {
   ],
   CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
   OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
-  OPEN_SITE: [(store, { siteId, href }) => {
-    sendMessage({ action: 'notifications_open_site', eventProperties:{ siteId }});
+  OPEN_SITE: [(store, { siteId: site_id, href }) => {
+    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_site', eventProperties:{ site_id }});
     window.open(href, '_blank');
   }],
-  OPEN_POST: [(store, { siteId, postId, href }) => {
-    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_post', eventProperties:{ siteId, postId }});
+  OPEN_POST: [(store, { siteId: site_id, postId: post_id, href }) => {
+    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_post', eventProperties:{ site_id, post_id }});
     window.open(href, '_blank');
   }],
-  OPEN_COMMENT: [(store, { siteId, postId, commentId, href }) => {
-    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_comment', eventProperties:{ siteId, postId, commentId }});
+  OPEN_COMMENT: [(store, { siteId: site_id, postId: post_id, commentId: comment_id, href }) => {
+    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_comment', eventProperties:{ site_id, post_id, comment_id }});
     window.open(href, '_blank');
   }],
   SET_LAYOUT: [

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -26,9 +26,18 @@ const customMiddleware = {
   ],
   CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
   OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
-  OPEN_SITE: [(store, { href }) => window.open(href, '_blank')],
-  OPEN_POST: [(store, { href }) => window.open(href, '_blank')],
-  OPEN_COMMENT: [(store, { href }) => window.open(href, '_blank')],
+  OPEN_SITE: [(store, { siteId, href }) => {
+    sendMessage({ action: 'notifications_open_site', eventProperties:{ siteId }});
+    window.open(href, '_blank');
+  }],
+  OPEN_POST: [(store, { siteId, postId, href }) => {
+    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_post', eventProperties:{ siteId, postId }});
+    window.open(href, '_blank');
+  }],
+  OPEN_COMMENT: [(store, { siteId, postId, commentId, href }) => {
+    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_comment', eventProperties:{ siteId, postId, commentId }});
+    window.open(href, '_blank');
+  }],
   SET_LAYOUT: [
     (store, { layout }) =>
       sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -26,16 +26,16 @@ const customMiddleware = {
   ],
   CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
   OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
-  OPEN_SITE: [(store, { siteId: site_id, href }) => {
-    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_site', eventProperties:{ site_id }});
+  OPEN_SITE: [(store, { siteId, href }) => {
+    sendMessage({ action: 'openSite', siteId });
     window.open(href, '_blank');
   }],
-  OPEN_POST: [(store, { siteId: site_id, postId: post_id, href }) => {
-    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_post', eventProperties:{ site_id, post_id }});
+  OPEN_POST: [(store, { siteId, postId, href }) => {
+    sendMessage({ action: 'openPost', siteId, postId });
     window.open(href, '_blank');
   }],
-  OPEN_COMMENT: [(store, { siteId: site_id, postId: post_id, commentId: comment_id, href }) => {
-    sendMessage({ action: 'recordEvent', eventName: 'notifications_open_comment', eventProperties:{ site_id, post_id, comment_id }});
+  OPEN_COMMENT: [(store, { siteId, postId, commentId, href }) => {
+    sendMessage({ action: 'openComment', siteId, postId, commentId });
     window.open(href, '_blank');
   }],
   SET_LAYOUT: [


### PR DESCRIPTION
This PR modifies the custom middleware on the standalone panel to send a special `recordEvent` message to the parent page. If the parent is the WordPress.com Jetpack Masterbar, provisions are made to receive that message and record a Tracks event with the information provided.

To test:
- Sandbox `widgets.wp.com`, `s0.wp.com`.
- Build this branch on your sandbox.
- Apply patch D7169-code on your sandbox.
- Open a Jetpack site with the Masterbar enabled.
- Open the Tracks live view on the MC.

You should see `jetpack_masterbar_notifications_open_site`, `jetpack_masterbar_notifications_open_post` and `jetpack_masterbar_notifications_open_comment` events when the corresponding actions are performed on the notifications panel.

References: 
Master Thread: Instrument Masterbar + Notifications (p3fqKv-5mr-p2)
Masterbar: adds overrides to send Tracks events (D7169-code)
Closes #181 