### PR TITLE
Gridicon: updates the reply icon

### DIFF
--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -194,7 +194,7 @@ export default React.createClass({
           <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <title>Reply</title>
             <g>
-              <path d="M14 8H6.828l2.586-2.586L8 4 3 9l5 5 1.414-1.414L6.828 10H14c2.206 0 4 1.794 4 4s-1.794 4-4 4h-2v2h2c3.314 0 6-2.686 6-6s-2.686-6-6-6z" />
+              <path d="M9 16h7.2l-2.6 2.6L15 20l5-5-5-5-1.4 1.4 2.6 2.6H9c-2.2 0-4-1.8-4-4s1.8-4 4-4h2V4H9c-3.3 0-6 2.7-6 6s2.7 6 6 6z" />
             </g>
           </svg>
         );


### PR DESCRIPTION
Fixes #186 

Updates the reply icon for consistency with the latest release of gridicons, since we are not using the npm package, but a subset of icons on `src/templates/gridicons.jsx`

https://github.com/Automattic/notifications-panel/blob/5ef66103dfcbabed9de0353d9ea27bb718cd6386/src/templates/gridicons.jsx#L192

Maybe we should consider using the npm package instead...

To test:
- run the local environment
- find a notification of a comment with a reply
- both the list view and the detail view should show the reply icon pointing to the right.

| Before | After |
|--|--|
| ![screen shot 2017-10-18 at 15 14 57](https://user-images.githubusercontent.com/233601/31735113-440f8586-b417-11e7-899d-98c642187bb0.png) | ![screen shot 2017-10-18 at 15 12 43](https://user-images.githubusercontent.com/233601/31735040-f8ad3098-b416-11e7-92a4-2057dca6c9eb.png) |
| ![screen shot 2017-10-18 at 15 15 23](https://user-images.githubusercontent.com/233601/31735135-58e9be40-b417-11e7-9be7-b3a7cd8e0855.png) | ![screen shot 2017-10-18 at 15 12 54](https://user-images.githubusercontent.com/233601/31735045-fc37485c-b416-11e7-9fd9-857c62534687.png) |

References:
https://github.com/Automattic/gridicons/pull/255
https://github.com/Automattic/wp-calypso/pull/18891
