### PR TITLE
Add cart icon to the list of allowed noticon2gridicons

### DIFF
--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -252,6 +252,17 @@ export default React.createClass({
             </g>
           </svg>
         );
+
+      case 'gridicons-cart':
+        return (
+          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <title>Cart</title>
+            <g>
+              <path d="M9 20c0 1.1-.9 2-2 2s-1.99-.9-1.99-2S5.9 18 7 18s2 .9 2 2zm8-2c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2zm.396-5c.937
+		 0 1.75-.65 1.952-1.566L21 5H7V4c0-1.105-.895-2-2-2H3v2h2v11c0 1.105.895 2 2 2h12c0-1.105-.895-2-2-2H7v-2h10.396z" />
+            </g>
+          </svg>
+        );
     }
   },
 });

--- a/src/utils/noticon2gridicon.js
+++ b/src/utils/noticon2gridicon.js
@@ -14,6 +14,7 @@ export const noticon2gridicon = c =>
       '\uf804': 'trophy',
       '\uf467': 'reply',
       '\uf414': 'warning',
+      '\uf447': 'cart',
     },
     c,
     'info'


### PR DESCRIPTION
This PR adds the `cart` icon to the noticon to gridicon transformation list, making it possible to use the `cart` icon for notifications.

We will be using this for a [new order notification for Store on WP.com](https://github.com/Automattic/wp-calypso/issues/16181).

<img width="400" alt="screen shot 2017-10-21 at 12 24 33 pm" src="https://user-images.githubusercontent.com/689165/31855473-beb8cb80-b660-11e7-9b96-031611cf5e63.png">

To Test:
* Install `notifications-panel` per the [README](https://github.com/Automattic/notifications-panel#installation).
* Load up this branch.
* Sandbox `public-api`.
* Open `class-notification-builders-v1-1.php`and find the builder for one of the notifications in your stream. For example, `build_post_reply` for a comment reply. 
* Update the `set_noticon` call to `$builder->set_noticon( 'cart' );`
* Load up the notifications panel (`http://notifications.dev:8888/`) and view.
* Verify that you can see the cart icon.
* (You could also load up D7802-code and generate an actual order notification - but I haven't completely written out the testing steps there and they are a bit more involved).