### PR TITLE
Migrate PropType references to external package to solve console warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mocha-jsdom": "1.1.0",
     "postcss-loader": "1.3.3",
     "prettier": "1.4.0",
+    "prop-types": "15.5.10",
     "sass-loader": "6.0.3",
     "style-loader": "0.16.0",
     "webpack-dev-server": "2.4.2"

--- a/src/Notifications.jsx
+++ b/src/Notifications.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { noop } from 'lodash';
 

--- a/src/templates/action-button.jsx
+++ b/src/templates/action-button.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**

--- a/src/templates/actions.jsx
+++ b/src/templates/actions.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/src/templates/button-approve.jsx
+++ b/src/templates/button-approve.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/src/templates/button-back.jsx
+++ b/src/templates/button-back.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 

--- a/src/templates/button-like.jsx
+++ b/src/templates/button-like.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/src/templates/button-spam.jsx
+++ b/src/templates/button-spam.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/src/templates/button-trash.jsx
+++ b/src/templates/button-trash.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/src/templates/container-hotkey.jsx
+++ b/src/templates/container-hotkey.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/src/templates/follow-link.jsx
+++ b/src/templates/follow-link.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 import { wpcom } from '../rest-client/wpcom';
@@ -8,8 +9,8 @@ import Gridicon from './gridicons';
 
 export const FollowLink = React.createClass({
   propTypes: {
-    site: React.PropTypes.number,
-    isFollowing: React.PropTypes.bool,
+    site: PropTypes.number,
+    isFollowing: PropTypes.bool,
   },
 
   followStatTypes: {

--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -2,15 +2,16 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export default React.createClass({
   displayName: 'Gridicons',
 
   propTypes: {
-    icon: React.PropTypes.string.isRequired,
-    size: React.PropTypes.number,
-    onClick: React.PropTypes.func,
+    icon: PropTypes.string.isRequired,
+    size: PropTypes.number,
+    onClick: PropTypes.func,
   },
 
   render: function() {

--- a/src/templates/image-loader.jsx
+++ b/src/templates/image-loader.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 
 /**

--- a/src/templates/nav-button.jsx
+++ b/src/templates/nav-button.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 


### PR DESCRIPTION
This PR solves these warnings in console:
```
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead.
```