### PR TITLE
Styling: Center all images by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.3
+
+### 1.3.1
+
+ - Center images in notification render. This was already happening for badge notifications and for
+   all images in the mobile apps, so this change is somewhat a harmonization more than a change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The core notifications panel for WordPress.com notifications",
   "esnext": "src/Notifications.jsx",
   "scripts": {

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -504,6 +504,13 @@ body {
       -webkit-overflow-scrolling: touch;
     }
 
+    .wpnc__image {
+      max-width: 100%;
+      margin: auto;
+      margin-left: 50%;
+      transform: translateX(-50%);
+    }
+
     .wpnc__user {
       p {
         @extend %ellipsy-box;

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -505,10 +505,9 @@ body {
     }
 
     .wpnc__image {
-      max-width: 100%;
+      display: block;
       margin: auto;
-      margin-left: 50%;
-      transform: translateX(-50%);
+      max-width: 100%;
     }
 
     .wpnc__user {


### PR DESCRIPTION
A couple times recently we have seen attempts to center images through
styles embedded in notification content directly or by using a "badge"
type notification. The problem with these approaches is that they end
up working around the system in the notifications panel and become
fragile and coupled to things that are implementation details instead
of design elements.

After discussion with a few people we realized that there is no reason
for us not to automatically center images displayed in the
notifications themselves. In fact, the mobile clients already do this.

In this patch we're centering all images inside of the notifications.
This should make it possible to do what people have wanted, which is
to have a left-aligned paragraph with a centered image which is also
not a badge/trophy notification.

**Testing**

You'll need to generate notifications with images inside of them in order
to test this. There are two or three primary circumstances I think we want
to test:

 - an image is wider than the notification display area
 - an image is narrow than the notification display area
 - an image doesn't specify its width

Some images will come as floating pieces inside of a post, for example. It
would be best to test these with a mention notification maybe as it will
pull in post contents. Some will have the images as their own blocks found
between paragraphs of text.

Just try to see if this breaks anything. It would be helpful to resize the
screen while testing to make sure the transforms don't break.

**Notes**

As always, my CSS skills are a bit `-weak-sauce:` so please don't hesitate
to critique the rules and offer a better alternative. I wrote what gave me my
desired result, not what I necessarily think is most appropriate.

**Before**
<img width="417" alt="screen shot 2017-11-15 at 3 40 22 pm" src="https://user-images.githubusercontent.com/5431237/32859034-51ef149a-ca1b-11e7-9201-af8f4c72b2d3.png">

**After**
<img width="411" alt="screen shot 2017-11-15 at 3 39 53 pm" src="https://user-images.githubusercontent.com/5431237/32859020-45146572-ca1b-11e7-9af7-52e1eb743d83.png">

From the screenshots you can see that the `max-width` rule makes some images expand.