### PR TITLE
Add support for checkmark icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 
  - Center images in notification render. This was already happening for badge notifications and for
    all images in the mobile apps, so this change is somewhat a harmonization more than a change.
+ - Support `checkmark` icon type in notes list.

--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -847,7 +847,11 @@ body {
         margin-top: 0px;
       }
 
-      -webkit-transform: translate3d(0, 0, 0); // fix for getting scrollbar in right z-index
+      -webkit-transform: translate3d(
+        0,
+        0,
+        0
+      ); // fix for getting scrollbar in right z-index
     }
 
     .wpnc__single-view {

--- a/src/utils/noticon2gridicon.js
+++ b/src/utils/noticon2gridicon.js
@@ -14,6 +14,7 @@ export const noticon2gridicon = c =>
       '\uf804': 'trophy',
       '\uf467': 'reply',
       '\uf414': 'warning',
+      '\uf418': 'checkmark',
       '\uf447': 'cart',
     },
     c,


### PR DESCRIPTION
Despite having the `checkmark` Gridicon checked-in to the project the
mapping from noticon index was missing in `noticon2gridicon`.

This patch adds the mapping and updates the patch version. No changes to
the code or operating are affected by this: it's only a bug-fix.

**Testing**

Find a note with the checkmark icon in it and see if it displays as a
checkmark or as an info `i`

**Before**
<img width="114" alt="screen shot 2017-11-15 at 5 26 53 pm" src="https://user-images.githubusercontent.com/5431237/32863653-31f867a4-ca2a-11e7-959e-fb7d3f6f0299.png">

**After**
<img width="114" alt="screen shot 2017-11-15 at 5 26 30 pm" src="https://user-images.githubusercontent.com/5431237/32863638-2a1a49a8-ca2a-11e7-8897-bd44b891e681.png">

**Creating a checkmark note**

Open up any note building in your sandbox and change the icon type to `checkmark`

Also, Jetpack monitor and auto-update notices use the checkmark, so it could be
possible to create one by taking down a Jetpack site temporarily.