### PR TITLE
Revert #174 to allow a working React 16 version with checkmark icons and centred images into Automattic/wp-calypso.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "notifications-panel",
-  "version": "1.3.1",
+  "version": "2.1.2",
   "description": "The core notifications panel for WordPress.com notifications",
-  "esnext": "src/Notifications.jsx",
+  "main": "src/Notifications.jsx",
   "scripts": {
     "build": "webpack",
     "build:prod": "NODE_ENV=production webpack -p",


### PR DESCRIPTION
The recent [checkmark icons](2e53fcf57091104d6f87ebb422a426a9a03fd5de) and [centred images](8a56601535cce42ab7207b89e83b5819575a515e) commits are needed soon in Calypso, which has started using v2.0.0 of `notifications-panel` since upgrading to React 16. Once https://github.com/Automattic/wp-calypso/pull/19698 is ready, this PR can be, uh, reverted back.

Reverts changes in 855fc305ab18e2d8e96e0eca3393c47be7b8729b, and allows Calypso to bump up to v2.1.2 without the needed work in https://github.com/Automattic/wp-calypso/pull/19698 holding things back.