### PR TITLE
Revert 174 to enable updates and bump react to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug": "2.6.3",
     "i18n-calypso": "1.7.2",
     "lodash": "4.17.4",
-    "node-sass": "4.5.1",
+    "node-sass": "4.5.3",
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-redux": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "notifications-panel",
-  "version": "1.3.1",
+  "version": "2.1.2",
   "description": "The core notifications panel for WordPress.com notifications",
-  "esnext": "src/Notifications.jsx",
+  "main": "src/Notifications.jsx",
   "scripts": {
     "build": "webpack",
     "build:prod": "NODE_ENV=production webpack -p",
@@ -37,9 +37,9 @@
     "i18n-calypso": "1.7.2",
     "lodash": "4.17.4",
     "node-sass": "4.5.1",
-    "react": "15.4.2",
-    "react-dom": "15.4.2",
-    "react-redux": "5.0.3",
+    "react": "16.2.0",
+    "react-dom": "16.2.0",
+    "react-redux": "5.0.6",
     "redux": "3.6.0",
     "webpack": "2.3.1",
     "wpcom": "5.3.0",


### PR DESCRIPTION
We were maintaining a 2.x line for React 16, now that this is in Calypso, let's bump the React version on notifications-panel master.

This also reverts esnext changes to notifications-panel since https://github.com/Automattic/wp-calypso/pull/19698 has not landed yet and is blocking an update of notifications-panel in Calypso.

@ockham let us know when you're ready for another try.

### Testing Instructions
- `npm install`
- `npm start`
- Local testing environment loads as expected.