### PR TITLE
Change the local development domain from `.dev` to `.localhost`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ The following sections describe what is required in order to locally develop thi
 ### Authentication domain
 
 When developing the app locally we need to fake its base URL because of the way that user authentication works.
-The [OAuth application](https://developer.wordpress.com/apps/52716) will only respond to a select number of domain origins.
+The [OAuth application](https://developer.wordpress.com/apps/56641) will only respond to a select number of domain origins.
 Thus the following line will need to exist in your local `/etc/hosts` file.
 The app will be served at this address when running the development server.
 
 ```
-127.0.0.1 notifications.dev
+127.0.0.1 notifications.localhost
 ```
 
 ### Installation
@@ -45,6 +45,6 @@ With the code and dependent libraries installed run the development server with 
 npm start
 ```
 
-After it boots up load the entry at [notifications.dev:8888](notifications.dev:8888) in your browser.
+After it boots up load the entry at [notifications.localhost:8888](notifications.localhost:8888) in your browser.
 
 [react]: https://facebook.github.io/react/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack",
     "build:prod": "NODE_ENV=production webpack -p",
-    "start": "make build && webpack-dev-server -d --host notifications.dev --port 8888 --inline --watch --hot --progress --content-base public",
+    "start": "make build && webpack-dev-server -d --host notifications.localhost --port 8888 --inline --watch --hot --progress --content-base public",
     "translate": "i18n-calypso -i ./public/build.min.js -o ./notifications-i18n.php -a notifications_i18n"
   },
   "browserslist": [

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -21,44 +21,57 @@ const customMiddleware = {
   APP_RENDER_NOTES: [
     (store, { latestType, newNoteCount }) =>
       newNoteCount > 0
-        ? sendMessage({ action: 'render', num_new: newNoteCount, latest_type: latestType })
+        ? sendMessage({
+            action: 'render',
+            num_new: newNoteCount,
+            latest_type: latestType,
+          })
         : sendMessage({ action: 'renderAllSeen' }),
   ],
   CLOSE_PANEL: [() => sendMessage({ action: 'togglePanel' })],
   OPEN_LINK: [(store, { href }) => window.open(href, '_blank')],
-  OPEN_SITE: [(store, { siteId, href }) => {
-    sendMessage({ action: 'openSite', siteId });
-    window.open(href, '_blank');
-  }],
-  OPEN_POST: [(store, { siteId, postId, href }) => {
-    sendMessage({ action: 'openPost', siteId, postId });
-    window.open(href, '_blank');
-  }],
-  OPEN_COMMENT: [(store, { siteId, postId, commentId, href }) => {
-    sendMessage({ action: 'openComment', siteId, postId, commentId });
-    window.open(href, '_blank');
-  }],
+  OPEN_SITE: [
+    (store, { siteId, href }) => {
+      sendMessage({ action: 'openSite', siteId });
+      window.open(href, '_blank');
+    },
+  ],
+  OPEN_POST: [
+    (store, { siteId, postId, href }) => {
+      sendMessage({ action: 'openPost', siteId, postId });
+      window.open(href, '_blank');
+    },
+  ],
+  OPEN_COMMENT: [
+    (store, { siteId, postId, commentId, href }) => {
+      sendMessage({ action: 'openComment', siteId, postId, commentId });
+      window.open(href, '_blank');
+    },
+  ],
   SET_LAYOUT: [
     (store, { layout }) =>
-      sendMessage({ action: 'widescreen', widescreen: layout === 'widescreen' }),
+      sendMessage({
+        action: 'widescreen',
+        widescreen: layout === 'widescreen',
+      }),
   ],
   VIEW_SETTINGS: [() => window.open('https://wordpress.com/me/notifications')],
 };
 
 const render = () => {
-    ReactDOM.render(
-        React.createElement(AuthWrapper(Notifications), {
-            clientId: 56641,
-            customEnhancer,
-            customMiddleware,
-            isShowing,
-            isVisible,
-            locale,
-            receiveMessage: sendMessage,
-            redirectPath: "/"
-        }),
-        document.getElementsByClassName("wpnc__main")[0]
-    );
+  ReactDOM.render(
+    React.createElement(AuthWrapper(Notifications), {
+      clientId: 56641,
+      customEnhancer,
+      customMiddleware,
+      isShowing,
+      isVisible,
+      locale,
+      receiveMessage: sendMessage,
+      redirectPath: '/',
+    }),
+    document.getElementsByClassName('wpnc__main')[0]
+  );
 };
 
 const init = () => {

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -46,19 +46,19 @@ const customMiddleware = {
 };
 
 const render = () => {
-  ReactDOM.render(
-    React.createElement(AuthWrapper(Notifications), {
-      clientId: 52716,
-      customEnhancer,
-      customMiddleware,
-      isShowing,
-      isVisible,
-      locale,
-      receiveMessage: sendMessage,
-      redirectPath: '/',
-    }),
-    document.getElementsByClassName('wpnc__main')[0]
-  );
+    ReactDOM.render(
+        React.createElement(AuthWrapper(Notifications), {
+            clientId: 56641,
+            customEnhancer,
+            customMiddleware,
+            isShowing,
+            isVisible,
+            locale,
+            receiveMessage: sendMessage,
+            redirectPath: "/"
+        }),
+        document.getElementsByClassName("wpnc__main")[0]
+    );
 };
 
 const init = () => {


### PR DESCRIPTION
Up to now, we have been using `notifications.dev` as the domain for local development. However, the `.dev` TLD is now valid, and [Google has forced its forwarding to HTTPS](https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/) as of Chrome 63. This patch instead has us use the `.localhost` TLD (same as Calypso).

I've chosen to add a new app specific to `.localhost` rather than updating the existing app, since this is a Chrome-only issue so far.

**Testing**

1. Load `master` at http://notifications.dev:3000 in Chrome 63+, and get a browser error after being redirected to the HTTPS-equivalent URL.
2. Switch to this branch, and load http://notifications.localhost:3000 . You should not be redirected, and instead see the prompt for OAuth. Continue, and notifications should load properly.
  