### PR TITLE
Add the latest version number to the `w.js` script.

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=9">
@@ -11,8 +12,10 @@
 	<meta name="git-describe" content="<%= htmlWebpackPlugin.options.gitDescribe %>">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese">
 </head>
+
 <body>
-<div class="wpnc__main"></div>
-<script charset="UTF-8" src="https://stats.wp.com/w.js"></script>
+	<div class="wpnc__main"></div>
+	<script charset="UTF-8" src="https://stats.wp.com/w.js?56"></script>
 </body>
+
 </html>


### PR DESCRIPTION
This will ensure that users aren't still loading older versions from cache. Noting that other file changes are from Prettier.

See: p7jreA-1s3-p2

**Testing**
Load this PR, look under Sources tab > `stats.wp.com`, and verify that the script listed there is `w.js?56`.
  