### PR TITLE
Identify the current user for Tracks stats.

### DIFF
--- a/standalone/auth-wrapper.jsx
+++ b/standalone/auth-wrapper.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import wpcom from 'wpcom';
 import proxyRequest from 'wpcom-proxy-request';
 
-const getStoredToken = () => {
+export const getStoredToken = () => {
     try {
         const [expiry, token] = localStorage.getItem('auth').split(':', 2);
 

--- a/standalone/auth-wrapper.jsx
+++ b/standalone/auth-wrapper.jsx
@@ -85,10 +85,21 @@ export const AuthWrapper = Wrapped => class extends Component {
         window.location.replace(uri);
     };
 
+    setTracksUser = () =>
+        this.state.wpcom
+        .me()
+        .get( { fields: 'ID,username' } )
+        .then( ( { ID, username } ) => {
+            window._tkq = window._tkq || [];
+            window._tkq.push( [ 'identifyUser', ID, username ] ) ;
+        } )
+        .catch( () => {} );
+
     render() {
         const { clientId, redirectPath, ...childProps } = this.props;
 
         if (this.state.wpcom) {
+            this.setTracksUser();
             return <Wrapped {...childProps} {...{ wpcom: this.state.wpcom }} />;
         }
 

--- a/standalone/auth-wrapper.jsx
+++ b/standalone/auth-wrapper.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import wpcom from 'wpcom';
 import proxyRequest from 'wpcom-proxy-request';
 
-export const getStoredToken = () => {
+const getStoredToken = () => {
     try {
         const [expiry, token] = localStorage.getItem('auth').split(':', 2);
 

--- a/standalone/auth-wrapper.jsx
+++ b/standalone/auth-wrapper.jsx
@@ -66,6 +66,12 @@ export const AuthWrapper = Wrapped => class extends Component {
         });
     }
 
+    componentDidUpdate(prevProps, prevState) {
+      if (!prevState.wpcom && this.state.wpcom) {
+        this.setTracksUser();
+      }
+    }
+
     maybeRedirectToOAuthLogin = () => {
         if (this.state.oAuthToken) {
             return this.setState({ wpcom: wpcom(this.state.oAuthToken) });
@@ -99,7 +105,6 @@ export const AuthWrapper = Wrapped => class extends Component {
         const { clientId, redirectPath, ...childProps } = this.props;
 
         if (this.state.wpcom) {
-            this.setTracksUser();
             return <Wrapped {...childProps} {...{ wpcom: this.state.wpcom }} />;
         }
 

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -1,10 +1,8 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
-import wpcom from 'wpcom';
-const debug = require('debug')('notifications:note');
 
 import Notifications, { refreshNotes } from '../src/Notifications';
-import AuthWrapper, { getStoredToken } from './auth-wrapper';
+import AuthWrapper from './auth-wrapper';
 import { receiveMessage, sendMessage } from './messaging';
 
 require('../src/boot/stylesheets/style.scss');
@@ -60,17 +58,6 @@ const customMiddleware = {
   VIEW_SETTINGS: [() => window.open('https://wordpress.com/me/notifications')],
 };
 
-const setTracksUser = () => {
-    wpcom( getStoredToken() )
-        .req
-        .get( { path: '/me', apiVersion: '1.1' }, { fields: 'ID,username' } )
-        .then( ( { ID, username } ) => {
-            window._tkq = window._tkq || [];
-            window._tkq.push( [ 'identifyUser', ID, username ] ) ;
-        })
-        .catch( () => debug( 'Error fetching user.') );
-};
-
 const render = () => {
   ReactDOM.render(
     React.createElement(AuthWrapper(Notifications), {
@@ -89,7 +76,6 @@ const render = () => {
 
 const init = () => {
   render();
-  setTracksUser();
 
   const refresh = () => store.dispatch({ type: 'APP_REFRESH_NOTES', isVisible });
   const reset = () => store.dispatch({ type: 'SELECT_NOTE', noteId: null });

--- a/standalone/index.js
+++ b/standalone/index.js
@@ -1,8 +1,10 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
+import wpcom from 'wpcom';
+const debug = require('debug')('notifications:note');
 
 import Notifications, { refreshNotes } from '../src/Notifications';
-import AuthWrapper from './auth-wrapper';
+import AuthWrapper, { getStoredToken } from './auth-wrapper';
 import { receiveMessage, sendMessage } from './messaging';
 
 require('../src/boot/stylesheets/style.scss');
@@ -58,6 +60,17 @@ const customMiddleware = {
   VIEW_SETTINGS: [() => window.open('https://wordpress.com/me/notifications')],
 };
 
+const setTracksUser = () => {
+    wpcom( getStoredToken() )
+        .req
+        .get( { path: '/me', apiVersion: '1.1' }, { fields: 'ID,username' } )
+        .then( ( { ID, username } ) => {
+            window._tkq = window._tkq || [];
+            window._tkq.push( [ 'identifyUser', ID, username ] ) ;
+        })
+        .catch( () => debug( 'Error fetching user.') );
+};
+
 const render = () => {
   ReactDOM.render(
     React.createElement(AuthWrapper(Notifications), {
@@ -76,6 +89,7 @@ const render = () => {
 
 const init = () => {
   render();
+  setTracksUser();
 
   const refresh = () => store.dispatch({ type: 'APP_REFRESH_NOTES', isVisible });
   const reset = () => store.dispatch({ type: 'SELECT_NOTE', noteId: null });


### PR DESCRIPTION
Some Tracks stats are currently being recorded as anonymous in the Notifications iframe (this is not an issue for Calypso, since `notifications-panel` is used directly as a module). This PR allows Tracks to run `identifyUser` from `w.js`, properly adding the current user to any subsequent `t.gif` requests.

**Testing - this repo**
* Load the standalone app with this PR, and open devtools to the Network tab.
* Filter for `t.gif`, and click on a note to open it.
* The resulting `t.gif` request should include `_ui` and `_ul` params with your user ID and username respectively.

**Testing - dotcom iframe**
* Build a fresh beta `notifications-client` on your sandbox, using `bin/build-sandbox.sh -bc add/tracks-user` and the repo's own instructions.
* Sandbox `widgets.wp.com`.
* Load the front-end of your sandboxed test site.
* Note that a successful call to the `/me` endpoint was made.
* Click on a note to open it, and check that a `t.gif` was requested, containing the same params mentioned in the above repo testing instructions.
  