### PR TITLE
Remove `catch()` from the `/me` call to avoid nooping on all failures.

### DIFF
--- a/standalone/auth-wrapper.jsx
+++ b/standalone/auth-wrapper.jsx
@@ -98,8 +98,7 @@ export const AuthWrapper = Wrapped => class extends Component {
         .then( ( { ID, username } ) => {
             window._tkq = window._tkq || [];
             window._tkq.push( [ 'identifyUser', ID, username ] ) ;
-        } )
-        .catch( () => {} );
+        } );
 
     render() {
         const { clientId, redirectPath, ...childProps } = this.props;


### PR DESCRIPTION
@gwwar I believe we discussed this also around #209 – did I understand this correctly?