### PR TITLE
Give new post notifications the same top padding as comments and mentions.

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -744,16 +744,16 @@ body {
     padding: 0 $padding-large $padding-medium;
   }
 
-  .wpnc__comment .wpnc__body .wpnc__body-content {
-    box-shadow: inset 4px 0 0 lighten($gray, 30);
-    border-bottom: 1px solid lighten($gray, 30);
-    margin: 0 0 0 $padding-medium;
-    padding-top: $padding-small;
-  }
-
+  .wpnc__comment .wpnc__body .wpnc__body-content,
+  .wpnc__new_post .wpnc__body .wpnc__body-content,
   .wpnc__automattcher .wpnc__body .wpnc__body-content {
     border-bottom: 1px solid lighten($gray, 30);
     padding-top: $padding-small;
+  }
+
+  .wpnc__comment .wpnc__body .wpnc__body-content {
+    box-shadow: inset 4px 0 0 lighten($gray, 30);
+    margin: 0 0 0 $padding-medium;
   }
 
   .wpnc__body-content .match {


### PR DESCRIPTION
This PR adds the same top padding to new posts as we already give to comments and mention notifs. This can't be better generalized (eg. a selector of just `.wpnc__body .wpnc__body-content`), since it starts to mess up other types (such as likes). Note that this will also fix cross-posts (they have the same `.wpnc__new_post` class).

![screen shot 2018-02-01 at 4 29 18 pm](https://user-images.githubusercontent.com/349751/35710698-b908d8fc-076d-11e8-84ce-5d77dab23c5f.png)

_Before_

![screen shot 2018-02-01 at 4 27 08 pm](https://user-images.githubusercontent.com/349751/35710702-bc6eacb0-076d-11e8-91d8-6fbff54ed7d4.png)

_After_

Fixes https://github.com/Automattic/wp-calypso/issues/21558

**Testing**
 - Load this branch and verify there is a top padding on `.wpnc__body_content` for new post notifs, as well as a border between the content and the Like star.
 - Check that comments, x-posts, and auto-mattchers are treated the same.