### PR TITLE
package.json: Change main to esnext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-panel",
-  "version": "2.1.4",
+  "version": "3.0.0",
   "description": "The core notifications panel for WordPress.com notifications",
   "esnext": "src/Notifications.jsx",
   "scripts": {


### PR DESCRIPTION
Reboot of #174. Don't merge yet!

Copying/updating #174's PR desc:

---

To better denote we're dealing with untranspiled code.

Companion Calypso PR: https://github.com/Automattic/wp-calypso/pull/19698

To provide a bit of an explanation -- `esnext` is a custom field.
* We'll specify it as a possible entry point for webpack to watch out for [here](https://github.com/Automattic/wp-calypso/pull/19698/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dR173).
* OTOH, we use it (as opposed to `main`) as a flag to indicate that this is a package's entrypoint for untranspiled code [here](https://github.com/Automattic/wp-calypso/pull/19698/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dR129).

This is a strategy found at http://2ality.com/2017/06/pkg-esnext.html.

Suggested order:
* Merge this
* Release new version
* Calypso: Include `notifications-panel` version bump with https://github.com/Automattic/wp-calypso/pull/19698
* Test https://github.com/Automattic/wp-calypso/pull/19698
* Merge https://github.com/Automattic/wp-calypso/pull/19698