### PR TITLE
Replace the current spinner with Calypso's new pure CSS spinner.

### DIFF
--- a/src/boot/stylesheets/actions.scss
+++ b/src/boot/stylesheets/actions.scss
@@ -49,8 +49,9 @@
     .wpnc__spinner {
       display: block;
       position: absolute;
-      right: 20px;
+      right: 32px;
       left: initial;
+      top: 24px;
     }
   }
 }

--- a/src/boot/stylesheets/spinner.scss
+++ b/src/boot/stylesheets/spinner.scss
@@ -1,22 +1,18 @@
 .wpnc__main {
   .wpnc__spinner {
+    display: flex;
+    align-items: center;
     position: relative;
     top: 50%;
   }
 
-  // Start https://github.com/Automattic/wp-calypso/blob/master/client/components/spinner/style.scss
   @keyframes rotate-spinner {
     100% {
       transform: rotate( 360deg );
     }
   }
 
-  .spinner {
-    display: flex;
-    align-items: center;
-  }
-
-  .spinner__outer, .spinner__inner {
+  .wpnc__spinner__outer, .wpnc__spinner__inner {
     margin: auto;
     box-sizing: border-box;
     border: 0.1em solid transparent;
@@ -25,16 +21,15 @@
     animation-name: rotate-spinner;
   }
 
-  .spinner__outer {
+  .wpnc__spinner__outer {
     border-top-color: $blue-medium;
   }
 
-  .spinner__inner {
+  .wpnc__spinner__inner {
     width: 100%;
     height: 100%;
     border-top-color: $blue-medium;
     border-right-color: $blue-medium;
     opacity: 0.4;
   }
-  // End https://github.com/Automattic/wp-calypso/blob/master/client/components/spinner/style.scss
 }

--- a/src/boot/stylesheets/spinner.scss
+++ b/src/boot/stylesheets/spinner.scss
@@ -1,138 +1,40 @@
-//CSS Spinner http://codepen.io/MichaelArestad/pen/4f837dd51dc09256115afc9218edda2c
-@keyframes ui-wpnc__spinner-rotate-right {
-  0% {
-    transform: rotate(0deg);
+.wpnc__main {
+  .wpnc__spinner {
+    position: relative;
+    top: 50%;
   }
-  25% {
-    transform: rotate(180deg);
-  }
-  50% {
-    transform: rotate(180deg);
-  }
-  75% {
-    transform: rotate(360deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
 
-@keyframes ui-wpnc__spinner-rotate-left {
-  0% {
-    transform: rotate(0deg);
+  // Start https://github.com/Automattic/wp-calypso/blob/master/client/components/spinner/style.scss
+  @keyframes rotate-spinner {
+    100% {
+      transform: rotate( 360deg );
+    }
   }
-  25% {
-    transform: rotate(0deg);
-  }
-  50% {
-    transform: rotate(180deg);
-  }
-  75% {
-    transform: rotate(180deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
 
-$size: 20px;
-$transition-speed: .4s;
-.wpnc__spinner {
-  position: relative;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  border-radius: 100%;
-  width: $size;
-  height: $size;
-  background: lighten($gray, 20);
+  .spinner {
+    display: flex;
+    align-items: center;
+  }
 
-  // before & after make the donut hole
-  &:before, &:after {
-    content: '';
-    position: absolute;
-    background: $white;
+  .spinner__outer, .spinner__inner {
+    margin: auto;
+    box-sizing: border-box;
+    border: 0.1em solid transparent;
     border-radius: 50%;
+    animation: 3s linear infinite;
+    animation-name: rotate-spinner;
   }
-  &:before {
-    $stroke: 1px;
 
-    width: $size - ($stroke * 2);
-    height: $size - ($stroke * 2);
-    top: $stroke;
-    left: $stroke;
+  .spinner__outer {
+    border-top-color: $blue-medium;
   }
-  &:after {
-    $stroke: 3px;
 
-    width: $size - ($stroke * 2);
-    height: $size - ($stroke * 2);
-    top: $stroke;
-    left: $stroke;
-  }
-  &:hover {
-    .left:before {
-      transition-delay: $transition-speed;
-    }
-    .right:before {
-      transition-delay: 0;
-    }
-  }
-  .side {
-    width: 50%;
+  .spinner__inner {
+    width: 100%;
     height: 100%;
-    overflow: hidden;
-    position: absolute;
-
-    &:before {
-      content: '';
-      border-radius: 500px;
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      background: $blue-medium;
-      transition: all $transition-speed .4s linear;
-    }
+    border-top-color: $blue-medium;
+    border-right-color: $blue-medium;
+    opacity: 0.4;
   }
-  .left {
-    left: 0;
-
-    &:before {
-      left: 100%;
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-      transform-origin: 0 50%;
-      transition-delay: 0;
-    }
-  }
-  .right {
-    left: 50%;
-
-    &:before {
-      left: -100%;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      transform-origin: 100% 50%;
-    }
-  }
-}
-
-.animated {
-  .side:before {
-    animation-iteration-count: infinite;
-    animation-timing-function: linear;
-    animation-duration: 3s;
-  }
-  .left:before {
-    animation-name: ui-wpnc__spinner-rotate-left;
-  }
-  .right:before {
-    animation-name: ui-wpnc__spinner-rotate-right;
-  }
-}
-
-.wpnc__loading-indicator .wpnc__spinner {
-  &:before, &:after {
-    background: $gray-light;
-  }
+  // End https://github.com/Automattic/wp-calypso/blob/master/client/components/spinner/style.scss
 }

--- a/src/templates/comment-reply-input.jsx
+++ b/src/templates/comment-reply-input.jsx
@@ -10,7 +10,7 @@ import getSiteSuggestions from '../state/selectors/get-site-suggestions';
  * Internal dependencies
  */
 import { disableKeyboardShortcuts, enableKeyboardShortcuts } from '../flux/input-actions';
-
+import Spinner from './spinner';
 import Suggestions from '../suggestions';
 import repliesCache from '../comment-replies-cache';
 import { wpcom } from '../rest-client/wpcom';
@@ -286,10 +286,7 @@ const CommentReplyInput = createReactClass({
 
     if (this.state.isSubmitting) {
       submitLink = (
-        <div className="wpnc__spinner animated">
-          <span className="side left" />
-          <span className="side right" />
-        </div>
+        <Spinner className="wpnc__spinner" />
       );
     } else {
       if (value.length) {

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -17,6 +17,7 @@ import FilterBar from './filter-bar';
 import Filters from './filters';
 import ListHeader from './list-header';
 import Note from './note';
+import Spinner from './spinner';
 import StatusBar from './status-bar';
 import UndoListItem from './undo-list-item';
 
@@ -355,10 +356,7 @@ export class NoteList extends React.Component {
             {notes}
             {this.props.isLoading &&
               <div style={loadingIndicatorVisibility} className="wpnc__loading-indicator">
-                <div className="wpnc__spinner animated">
-                  <span className="side left" />
-                  <span className="side right" />
-                </div>
+                <Spinner className="wpnc__spinner" />
               </div>}
           </ol>
         </div>

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -356,7 +356,7 @@ export class NoteList extends React.Component {
             {notes}
             {this.props.isLoading &&
               <div style={loadingIndicatorVisibility} className="wpnc__loading-indicator">
-                <Spinner className="wpnc__spinner" />
+                <Spinner />
               </div>}
           </ol>
         </div>

--- a/src/templates/spinner.jsx
+++ b/src/templates/spinner.jsx
@@ -23,7 +23,7 @@ export default class Spinner extends PureComponent {
 	};
 
 	render() {
-		const className = classNames( 'spinner', this.props.className );
+		const className = classNames( 'wpnc__spinner', this.props.className );
 
 		const style = {
 			width: this.props.size,
@@ -33,8 +33,8 @@ export default class Spinner extends PureComponent {
 
 		return (
 			<div className={ className }>
-				<div className="spinner__outer" style={ style }>
-					<div className="spinner__inner" />
+				<div className="wpnc__spinner__outer" style={ style }>
+					<div className="wpnc__spinner__inner" />
 				</div>
 			</div>
 		);

--- a/src/templates/spinner.jsx
+++ b/src/templates/spinner.jsx
@@ -1,0 +1,42 @@
+/** @format */
+
+/**
+ * Source: https://github.com/Automattic/wp-calypso/blob/master/client/components/spinner/index.jsx
+ */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+
+export default class Spinner extends PureComponent {
+	static propTypes = {
+		className: PropTypes.string,
+		size: PropTypes.number,
+	};
+
+	static defaultProps = {
+		size: 20,
+	};
+
+	render() {
+		const className = classNames( 'spinner', this.props.className );
+
+		const style = {
+			width: this.props.size,
+			height: this.props.size,
+			fontSize: this.props.size, // allows border-width to be specified in em units
+		};
+
+		return (
+			<div className={ className }>
+				<div className="spinner__outer" style={ style }>
+					<div className="spinner__inner" />
+				</div>
+			</div>
+		);
+	}
+}


### PR DESCRIPTION
This PR replaces the original poorly-performing spinner with a simpler CSS spinner, which was recently updated in Calypso.

![spinner](https://user-images.githubusercontent.com/349751/36620938-5a05a1ac-18aa-11e8-9add-df621ba233e8.gif)

Fixes #234 .

**Testing**
- Change both the `isLoading` prop [here](https://github.com/Automattic/notifications-panel/blob/master/src/templates/note-list.jsx#L371) and the `isSubmitting` prop [here](https://github.com/Automattic/notifications-panel/blob/master/src/templates/comment-reply-input.jsx#L49) to `true`, so you can see what's going on.
- Load notifications, and verify the note list spinner is correct.
- Reply to a comment, and verify the reply spinner looks correct.