### PR TITLE
Edit Comment: Remove title tag from pencil Gridicon

### DIFF
--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -268,7 +268,6 @@ export default class extends React.Component {
       case 'gridicons-pencil':
         return (
           <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <title>Cart</title>
             <g>
               <path d="M13,6l5,5l-9.507,9.507c-0.686-0.686-0.689-1.794-0.012-2.485l-0.003-0.003c-0.691,0.677-1.799,0.674-2.485-0.012
 		c-0.677-0.677-0.686-1.762-0.036-2.455l-0.008-0.008c-0.693,0.649-1.779,0.64-2.455-0.036L13,6z M20.586,5.586l-2.172-2.172


### PR DESCRIPTION
Fix issue reported here: https://github.com/Automattic/wp-calypso/pull/23278#issuecomment-372975917

Remove the `<title>` tag from the `pencil` Gridicon which overrode the [button title](https://github.com/Automattic/notifications-panel/blob/master/src/templates/button-edit.jsx#L28).

Also, the previous title tag was incorrect because of a wrong copy-paste fixed in a commit accidentally dropped during [a rebase that reverted some unnecessary changes](https://github.com/Automattic/notifications-panel/pull/222#issuecomment-371887640).

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/1182160/37397231-59f6e2b8-277b-11e8-99d8-27f62aa0df8b.png" width="400px" /> | <img width="395" alt="screen shot 2018-03-14 at 10 58 21" src="https://user-images.githubusercontent.com/2070010/37398518-bb585dac-2776-11e8-8035-2445622c2332.png"> |