### PR TITLE
Update Gridicons style when they are used in a paragraph

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -661,6 +661,9 @@ body {
           display: block;
         }
       }
+      .wpnc__gridicon {
+        vertical-align: text-top;
+      }
 
       pre {
         background: $gray-light;


### PR DESCRIPTION
Fixes the alignment of gridicon when used in a paragraph such as in the monitor downtime. 

Before:
<img width="803" alt="screen shot 2018-04-04 at 11 44 40 am" src="https://user-images.githubusercontent.com/115071/38327874-3f9fdaa8-37fe-11e8-8a68-e5c578e21a0b.png">

After:
<img width="797" alt="screen shot 2018-04-04 at 11 49 09 am" src="https://user-images.githubusercontent.com/115071/38327869-3b34f638-37fe-11e8-87c4-8995fb035b94.png">

Related to https://github.com/Automattic/jetpack/issues/7892#issuecomment-375001662

