### PR TITLE
Add/offline gridicon

### DIFF
--- a/src/boot/stylesheets/main.scss
+++ b/src/boot/stylesheets/main.scss
@@ -121,6 +121,10 @@ body {
   .gridicon {
     fill: currentColor;
   }
+  
+  .gridicons-offline {
+    margin:1px 0 0 1px;
+  }
 
   .wpnc__user__username, span.wpnc__user {
     font-weight: 600;

--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -36,6 +36,14 @@ export default class extends React.Component {
           </svg>
         );
 
+      case 'gridicons-offline':
+        return (
+          <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <rect x="0" fill="none" width="24" height="24"/>
+            <g><path d="M10 3h8l-4 6h4L6 21l4-9H6l4-9"/></g>
+          </svg>
+        );
+
       case 'gridicons-spam':
         return (
           <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/src/templates/gridicons.jsx
+++ b/src/templates/gridicons.jsx
@@ -39,8 +39,8 @@ export default class extends React.Component {
       case 'gridicons-offline':
         return (
           <svg {...sharedProps} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <rect x="0" fill="none" width="24" height="24"/>
-            <g><path d="M10 3h8l-4 6h4L6 21l4-9H6l4-9"/></g>
+            <rect x="0" fill="none" width="24" height="24" />
+            <g><path d="M10 3h8l-4 6h4L6 21l4-9H6l4-9" /></g>
           </svg>
         );
 

--- a/src/utils/noticon2gridicon.js
+++ b/src/utils/noticon2gridicon.js
@@ -16,6 +16,7 @@ export const noticon2gridicon = c =>
       '\uf414': 'warning',
       '\uf418': 'checkmark',
       '\uf447': 'cart',
+      'offline': 'offline'
     },
     c,
     'info'


### PR DESCRIPTION
Currently we don't have a offline gridicon. 
The icon is not something that is pressent as a noteicon. So in order to get the icon to appear we will have to set the new icon slug in the api. 

In https://github.com/Automattic/jetpack/issues/7892#issuecomment-375001662 it was suggested that we used the offline gridicon instead of the current (default) icon for the notification. 

This PR one of the steps in adding the icon to notification. 

See: <img width="392" alt="screen shot 2018-04-04 at 3 29 40 pm" src="https://user-images.githubusercontent.com/115071/38338130-09a6f246-381d-11e8-98c3-b1216a02bd17.png">

This PR does not fit the whole issue just adds the missing icon