### PR TITLE
Try to use favicon for no-blavatar sites.

### DIFF
--- a/src/templates/block-user.jsx
+++ b/src/templates/block-user.jsx
@@ -13,6 +13,16 @@ function getDisplayURL(url) {
   return (parser.hostname + parser.pathname).replace(/\/$/, '');
 }
 
+function getProtocol( url ) {
+	var parser = document.createElement( 'a' );
+	parser.href = url;
+	return parser.protocol;
+}
+
+// This is the default blavatar sent by wpcom in the notification data if
+// blavatar is blank
+var defaultBlavatarURL = 'https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536';
+
 export class UserBlock extends React.Component {
   /**
 	 * Format a timestamp for showing how long
@@ -59,12 +69,14 @@ export class UserBlock extends React.Component {
 
   render() {
     var grav = this.props.block.media[0],
+      component = this,
       home_url = '',
       home_title = '',
       timeIndicator,
       homeTemplate,
       followLink,
-      noteActions;
+      noteActions,
+      image;
 
     if (this.props.block.meta) {
       if (this.props.block.meta.links) {
@@ -133,10 +145,18 @@ export class UserBlock extends React.Component {
     }
 
     if (home_url) {
+			if ( grav.url.indexOf( defaultBlavatarURL ) > -1 ) {
+				grav.url = getProtocol( home_url ) + '//' + getHostName( home_url ) + '/favicon.ico';
+				image = <img ref='icon' src={grav.url} onError={ function() {
+					component.refs.icon.getDOMNode().src = defaultBlavatarURL;
+				} } />;
+			} else {
+				image = <img src={grav.url} />;
+			}
       return (
         <div className="wpnc__user">
           <a className="wpnc__user__site" href={home_url} target="_blank">
-            <img src={grav.url} height={grav.height} width={grav.width} />
+            { image }
           </a>
           <span className="wpnc__user__username">
             <a className="wpnc__user__home" href={home_url} target="_blank">
@@ -150,7 +170,7 @@ export class UserBlock extends React.Component {
     } else {
       return (
         <div className="wpnc__user">
-          <img src={grav.url} height={grav.height} width={grav.width} />
+          <img src={grav.url} />
           <span className="wpnc__user__username">{this.props.block.text}</span>
           {homeTemplate}
           {followLink}


### PR DESCRIPTION
_Copied over from `notifications-client` pull #449_

Resolves #357 - we want to be able to use the favicon for a site if they don't have a blavatar.

What happens before this PR:

In the notification builder, we attempt to retrieve the blavatar_url(), if it's blank, we set the image for these pingback header blocks to a default blavatar url (mystery man).

What we want:

We would like to load the favicon.ico (if they have one).

What happens after this PR:

In building this user block, we check the image url, if it's the same as the default blavatar url, we switch it for the favicon.ico url. We add an error handler in case the site does not have a favicon. If there's an error loading, then we swap the image for the original default blavatar (mystery man image).

Now then:

If the site has a blavatar => use the blavatar like before
If the site has no blavatar and a favicon.ico => uses the favicon.ico (for wordpress.com sites, this means the default image becomes the W logo instead of the mystery man)
If the site has no blavatar and no favicon.ico => falls back to the default blavatar (mystery man)