### PR TITLE
Improve link destinations for empty filters.

### DIFF
--- a/src/templates/filters.js
+++ b/src/templates/filters.js
@@ -93,7 +93,7 @@ export const Filters = {
       emptyLinkMessage: i18n.translate("Get noticed: comment on posts you've read.", {
         comment: 'Notifications likes filter: no Notifications',
       }),
-      emptyLink: 'https://wordpress.com/posts/',
+      emptyLink: 'https://wordpress.com/activities/likes/',
 
       filter: ({ type }) => 'comment_like' === type || 'like' === type,
     };

--- a/src/templates/filters.js
+++ b/src/templates/filters.js
@@ -57,7 +57,7 @@ export const Filters = {
           comment: 'Notifications comments filter: no notifications',
         }
       ),
-      emptyLink: 'https://wordpress.com/read/',
+      emptyLink: 'https://wordpress.com/read/search/',
 
       filter: ({ type }) => 'comment' === type,
     };
@@ -75,7 +75,7 @@ export const Filters = {
       emptyLinkMessage: i18n.translate("Get noticed: comment on posts you've read.", {
         comment: 'Notifications follows filter: no notifications',
       }),
-      emptyLink: 'https://wordpress.com/read/',
+      emptyLink: 'https://wordpress.com/activities/likes/',
 
       filter: ({ type }) => 'follow' === type,
     };


### PR DESCRIPTION
Suggested by @designsimply and @rachelmcr in https://github.com/Automattic/notifications-client/issues/609.

This updates the empty Likes text to link to https://wordpress.com/activities/likes , and the empty Comments to https://wordpress.com/read/search

**Testing**
* Start notifications from this repo.
* Log in as a user with no Likes or Comments.
* Verify the content goes to its proper destination.