### PR TITLE
Fix sticky headers not displayed in electron

### DIFF
--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -333,7 +333,7 @@ export class NoteList extends React.Component {
     }
 
     const classes = classNames('wpnc__note-list', {
-      'disable-sticky': !!window.chrome, // position: sticky doesn't work in Chrome
+      'disable-sticky': !!window.chrome || !!window.electron, // position: sticky doesn't work in Chrome – `window.chrome` does not exist in electron
       'is-note-open': !!this.props.selectedNoteId,
     });
 


### PR DESCRIPTION
`window.chrome` is not available in electron and therefore the sticky headers aren't displayed in the desktop app.

**From this:**
<img width="412" alt="screen shot 2018-07-25 at 13 19 35" src="https://user-images.githubusercontent.com/3265004/43198023-684c6a22-900d-11e8-9d19-58ee5e5bfd22.png">

**To this:**
<img width="411" alt="screen shot 2018-07-25 at 13 18 39" src="https://user-images.githubusercontent.com/3265004/43198030-7140a6de-900d-11e8-96e2-d4dc887ccffe.png">

closes #284