### PR TITLE
Hide loading Spinner animation when the panel is not open

### DIFF
--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -354,7 +354,7 @@ export class NoteList extends React.Component {
               statusReset={this.resetStatusBar}
             />
             {notes}
-            {this.props.isLoading &&
+            {this.props.isLoading && this.props.isPanelOpen &&
               <div style={loadingIndicatorVisibility} className="wpnc__loading-indicator">
                 <Spinner />
               </div>}

--- a/src/templates/note-list.jsx
+++ b/src/templates/note-list.jsx
@@ -354,7 +354,8 @@ export class NoteList extends React.Component {
               statusReset={this.resetStatusBar}
             />
             {notes}
-            {this.props.isLoading && this.props.isPanelOpen &&
+            {this.props.isLoading &&
+              this.props.isPanelOpen &&
               <div style={loadingIndicatorVisibility} className="wpnc__loading-indicator">
                 <Spinner />
               </div>}


### PR DESCRIPTION
Today @pablinos mentioned that he was seeing high CPU usage while editing a post in Calypso, while using Firefox on macOS.

Tracking down the issue revealed that this was caused by the loading spinner constantly animating, even if the panel is not visible. 

Seems there's an issue in Firefox and how it handles "invisible" animations, which makes it always animate them, even if they're off-screen or behind other elements.

The bug is not present in Chrome. 

To reproduce:

1. In Firefox on macOS (haven't tested other versions of FF)
2. Open Calypso in My Sites context
3. Wait for it to settle
4. Notice CPU usage in Activity Monitor on Mac
5. In Firefox's DevTools, find element with class name `wpnc__spinner`
6. Either set `display:none` to it or delete it from the DOM
7. Wait a few seconds for FF to settle down
8. Notice CPU usage. 

If the bug is present, the CPU usage should go down with about 7-12% for the `FirefoxCP Web Content` process.

The proposed fix just makes sure the spinner is not rendered when the panel is not open in order to prevent the issue. 

Similar issue was seen and documented before in p4TIVU-6O6-p2 .